### PR TITLE
(CM-413) Output organisation name in host editions

### DIFF
--- a/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -83,7 +83,7 @@ private
         text: content_item.instances,
       },
       {
-        text: organisation_link(content_item),
+        text: content_item.publishing_organisation.fetch("title", nil),
       },
       {
         text: updated_field_for(content_item),
@@ -127,29 +127,6 @@ private
   def content_link(content_item)
     link_to(content_link_text(content_item),
             frontend_path(content_item), class: "govuk-link", target: "_blank", rel: "noopener")
-  end
-
-  def organisation_link(_content_item)
-    # TODO: Migrate code to fetch organisations from Publishing API
-    # return nil if content_item.nil?
-    #
-    # matching_organisation = all_publishing_organisations.find_by_content_id(content_item.publishing_organisation["content_id"])
-    # if matching_organisation
-    #   link_to(matching_organisation.name, admin_organisation_path(matching_organisation), class: "govuk-link")
-    # else
-    #   content_item.publishing_organisation.fetch("title", nil)
-    # end
-    nil
-  end
-
-  def all_publishing_organisations
-    @all_publishing_organisations ||= begin
-      host_content_ids = host_content_items.map { |content_item|
-        content_item.publishing_organisation.fetch("content_id", nil)
-      }.compact
-
-      Organisation.where(content_id: host_content_ids)
-    end
   end
 
   def updated_field_for(content_item)

--- a/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -95,44 +95,9 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       end
       assert_selector "tbody .govuk-table__cell", text: host_content_item.document_type.humanize
       assert_selector "tbody .govuk-table__cell", text: "1.2m"
-      # TODO: Migrate code to fetch organisations from Publishing API
-      # assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]
+      assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]
       assert_selector "tbody .govuk-table__cell", text: "#{time_ago_in_words(host_content_item.last_edited_at)} ago by #{last_edited_by_editor.name}"
       assert_link last_edited_by_editor.name, { href: content_block_manager_user_path(last_edited_by_editor.uid) }
-    end
-
-    context "when the organisation does NOT exist within Whitehall" do
-      it "does not link to the organisation" do
-        render_inline(
-          described_class.new(
-            caption:,
-            host_content_items:,
-            content_block_edition:,
-          ),
-        )
-        assert_no_selector "tbody .govuk-table__cell a", text: host_content_item.publishing_organisation["title"]
-      end
-    end
-
-    context "when the organisation DOES exist within Whitehall" do
-      it "links to the organisation instead of printing the name" do
-        skip("Skipping until we can fetch organisations from Publishing API")
-        organisation = create(:organisation, content_id: host_content_item.publishing_organisation["content_id"], name: host_content_item.publishing_organisation["title"])
-
-        expected_href = Rails.application.routes.url_helpers.admin_organisation_path(organisation)
-
-        render_inline(
-          described_class.new(
-            caption:,
-            host_content_items:,
-            content_block_edition:,
-          ),
-        )
-        assert_selector "tbody .govuk-table__cell a",
-                        text: host_content_item.publishing_organisation["title"]
-
-        assert_link host_content_item.publishing_organisation["title"], href: expected_href
-      end
     end
 
     context "when the organisation received does not have a title or base_path" do


### PR DESCRIPTION
Before, we linked out to an organisation in Whitehall, which we can’t do now. The usefulness of this is probably limited anyway, so for now, let’s just show the organisation’s name.