### PR TITLE
(CM-146) Update database name

### DIFF
--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "GovukContentBlockManager",
+  "name": "ContentBlockManager",
   "icons": [
     {
       "src": "/icon.png",

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module GovukContentBlockManager
+module ContentBlockManager
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,15 +6,15 @@ default: &default
 
 development:
   <<: *default
-  database: govuk-content-block-manager_development
+  database: content_block_manager_development
   url: <%= ENV["DATABASE_URL"]%>
 
 test:
   <<: *default
-  database: govuk-content-block-manager_test
+  database: content_block_manager_test
   url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   <<: *default
-  database: govuk-content-block-manager_production
+  database: content_block_manager_production
   url: <%= ENV["DATABASE_URL"]%>

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,3 +1,5 @@
+require_relative "../lib/content_block_manager"
+
 Flipflop.configure do
   # Strategies will be used in the order listed here.
   strategy :active_record, hidden: !Rails.env.development?

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk-content-block-manager",
+  "name": "content-block-manager",
   "description": "Create and manage re-usable blocks of content",
   "private": true,
   "author": "Government Digital Service",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,7 @@ require "govuk_sidekiq/testing"
 
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 
-GovukContentBlockManager::Application.load_tasks if Rake::Task.tasks.empty?
+ContentBlockManager::Application.load_tasks if Rake::Task.tasks.empty?
 
 Mocha.configure do |c|
   c.stubbing_non_existent_method = :prevent

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,9 +42,9 @@
   integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
 
 "@dual-bundle/import-meta-resolve@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz#519c1549b0e147759e7825701ecffd25e5819f7b"
-  integrity sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz#cd0b25b3808cd9e684cd6cd549bbf8e1dcf05ee7"
+  integrity sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.0":
   version "4.7.0"
@@ -2023,9 +2023,9 @@ jasmine-browser-runner@^3.0.0:
     selenium-webdriver "^4.12.0"
 
 jasmine-core@^5.9.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-5.9.0.tgz#140199862ee83f906bf0ff88287e7c440a1776e7"
-  integrity sha512-OMUvF1iI6+gSRYOhMrH4QYothVLN9C3EJ6wm4g7zLJlnaTl8zbaPOr0bTw70l7QxkoM7sVFOWo83u9B2Fe2Zng==
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-5.10.0.tgz#7e6c3efde6eb1ec9afc58d4373f6ace1e91c459e"
+  integrity sha512-MrChbWV5LBo+EaeKwTM1eZ6oYSz1brvFExnRafraEkJkbJ9evbUxABhnIgGQimhpMxhg+BD6QmOvb/e3NXsNdg==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We'd setup the prod database name to be `content_block_manager_production` (as defined in the secret here https://github.com/alphagov/govuk-helm-charts/blob/517899d7fe694bf61b611d43e29b69d1c68b9c09/charts/external-secrets/templates/content-block-manager/postgresql.yaml#L20), which is different to what's in the database.yml, so the pods aren't coming up cleanly.

The database names we do have use the `govuk` prefix, which we removed from the repo name. Rather than keep the old legacy name, let's change it to something predictable. I've also removed the `Govuk` prefix from the app name to keep things consistent.