### PR TITLE
(CM-416) Only run seeds in development

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-return if Rails.env.test?
+return unless Rails.env.development?
 
 User.create!(
   name: "Test user",


### PR DESCRIPTION
We’re planning to update the Helm charts to run `rails db:setup` instead of `rails db:migrate`, so we can create the database. This will also run the seeds, so we need to ensure they’re not run in production.