### PR TITLE
(CM-416) Add `assets.prefix` to the Asset config

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,5 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
+# Path within public/ where assets are compiled to
+Rails.application.config.assets.prefix = "/assets/content_block_manager"
+
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = "1.0"
 

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/content_block_manager",
   "srcFiles": [
     "test-dependencies-*.js",
     "application-*.js",


### PR DESCRIPTION
Apparently we need this for the app to come up cleanly