### PR TITLE
(CM-416) Only fetch fields we need for Organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,7 +2,6 @@ class Organisation < Data.define(:id, :name)
   class << self
     def all
       Rails.cache.fetch "organisations", expires_in: 1.day do
-        api_response = Services.publishing_api.get_content_items(document_type: "organisation", per_page: "500")
         api_response["results"].map do |organisation|
           new(id: organisation["content_id"], name: organisation["title"])
         end
@@ -11,6 +10,16 @@ class Organisation < Data.define(:id, :name)
 
     def find(id)
       all.find { |org| org.id == id }
+    end
+
+  private
+
+    def api_response
+      Services.publishing_api.get_content_items(
+        document_type: "organisation",
+        fields: %w[title content_id],
+        per_page: "500",
+      )
     end
   end
 end

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -27,7 +27,9 @@ class ContentBlockManager::OrganisationTest < ActiveSupport::TestCase
 
     it "fetches organisations" do
       Services.publishing_api.expects(:get_content_items)
-              .with(document_type: "organisation", per_page: "500")
+              .with(document_type: "organisation",
+                    fields: %w[title content_id],
+                    per_page: "500")
               .returns(results)
 
       organisations = Organisation.all
@@ -43,7 +45,9 @@ class ContentBlockManager::OrganisationTest < ActiveSupport::TestCase
 
     it "caches results" do
       Services.publishing_api.expects(:get_content_items)
-              .with(document_type: "organisation", per_page: "500")
+              .with(document_type: "organisation",
+                    fields: %w[title content_id],
+                    per_page: "500")
               .once
               .returns(results)
 


### PR DESCRIPTION
This will cut down on the API response time, which is timing out at the moment.