### PR TITLE
(CM-416) Add `terser` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "rails", "~> 8.0.2", ">= 8.0.2.1"
 gem "record_tag_helper", require: false
 gem "rinku", require: "rails_rinku"
 gem "sprockets-rails"
+gem "terser"
 gem "thruster", require: false
 gem "transitions", require: ["transitions", "active_record/transitions"]
 gem "tzinfo-data", platforms: %i[windows jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
+    execjs (2.10.0)
     factory_bot (6.5.5)
       activesupport (>= 6.1.0)
     faker (3.5.2)
@@ -869,6 +870,8 @@ GEM
       memoist3 (~> 1.0.0)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    terser (1.2.6)
+      execjs (>= 0.3.0, < 3)
     thor (1.4.0)
     thruster (0.1.15)
     thruster (0.1.15-aarch64-linux)
@@ -970,6 +973,7 @@ DEPENDENCIES
   rubocop-govuk
   simplecov
   sprockets-rails
+  terser
   thruster
   timecop
   transitions


### PR DESCRIPTION
This is required by the changes we made in https://github.com/alphagov/content-block-manager/pull/30