### PR TITLE
CM-419: fetch countries from Publishing API

### DIFF
--- a/app/components/content_block_manager/content_block/edition/details/fields/country_component.rb
+++ b/app/components/content_block_manager/content_block/edition/details/fields/country_component.rb
@@ -2,9 +2,7 @@ class ContentBlockManager::ContentBlock::Edition::Details::Fields::CountryCompon
   BLANK_OPTION = "United Kingdom".freeze
 
   def initialize(**args)
-    # TODO: Comment out until we have migrated WorldLocations to come from Publishing API
-    # countries = WorldLocation.geographical.map(&:name)
-    countries = ["United Kingdom", "United States of America", "France"]
+    countries = WorldLocation.countries.map(&:name)
     super(**args.merge(enum: countries))
   end
 

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -1,0 +1,21 @@
+class WorldLocation < Data.define(:name)
+  class << self
+    def countries
+      Rails.cache.fetch "world_locations", expires_in: 1.day do
+        api_response["results"]
+          .map { |location| new(name: location["title"]) }
+          .sort_by(&:name)
+      end
+    end
+
+  private
+
+    def api_response
+      Services.publishing_api.get_content_items(
+        document_type: "world_location",
+        fields: %w[title],
+        per_page: "500",
+      )
+    end
+  end
+end

--- a/test/components/content_block/edition/details/fields/country_component_test.rb
+++ b/test/components/content_block/edition/details/fields/country_component_test.rb
@@ -6,14 +6,13 @@ class ContentBlockManager::ContentBlock::Edition::Details::Fields::CountryCompon
   let(:content_block_edition) { build(:content_block_edition, :pension) }
   let(:field) { stub("field", name: "country", is_required?: true, default_value: nil) }
 
-  # let(:world_locations) { 5.times.map { |i| build(:world_location, name: "World location #{i}") } }
-  # let(:uk) { build(:world_location, name: "United Kingdom") }
+  let(:world_locations) { 5.times.map { |i| build(:world_location, name: "World location #{i}") } }
+  let(:uk) { build(:world_location, name: "United Kingdom") }
 
-  # let(:all_locations) { [world_locations, uk].flatten }
+  let(:all_locations) { [world_locations, uk].flatten }
 
   before do
-    skip("Skip these until we have migrated WorldLocations to come from Publishing API")
-    # WorldLocation.stubs(:geographical).returns(all_locations)
+    WorldLocation.stubs(:countries).returns(all_locations)
   end
 
   it "should render an select field populated with WorldLocations with the UK as the blank option" do

--- a/test/factories/world_locations.rb
+++ b/test/factories/world_locations.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :world_location, class: "WorldLocation" do
+    sequence(:name) { |index| "world-location-#{index}" }
+  end
+
+  initialize_with do
+    new(**attributes)
+  end
+end

--- a/test/unit/app/models/world_location_test.rb
+++ b/test/unit/app/models/world_location_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class ContentBlockManager::WorldLocationTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+  before do
+    Rails.stubs(:cache).returns(memory_store)
+    Rails.cache.clear
+  end
+
+  describe "#countries" do
+    let(:uk) { { "title" => "United Kingdom" } }
+    let(:usa) { { "title" => "United States of America" } }
+    let(:france) { { "title" => "France" } }
+
+    let(:response) do
+      {
+        "results" => [uk, usa, france],
+      }
+    end
+
+    it "fetches locations and orders them alphabetically" do
+      Services.publishing_api.expects(:get_content_items)
+              .with(document_type: "world_location",
+                    fields: %w[title],
+                    per_page: "500")
+              .returns(response)
+
+      expected_countries = [
+        "France",
+        "United Kingdom",
+        "United States of America",
+      ]
+
+      locations = WorldLocation.countries
+
+      assert_equal 3, locations.size
+      assert_equal expected_countries, locations.map(&:name)
+    end
+
+    it "caches results" do
+      Services.publishing_api.expects(:get_content_items)
+              .with(document_type: "world_location",
+                    fields: %w[title],
+                    per_page: "500")
+              .once
+              .returns(response)
+
+      assert(5.times { WorldLocation.countries })
+    end
+  end
+end


### PR DESCRIPTION
See Jira [CM-419](https://gov-uk.atlassian.net/browse/CM-419)

Rather than use a hard-coded list of 3 countries our
`CountryComponent` now uses the new `WorldLocation.countries`
method, which fetches, orders and caches the list of
countries from the Publishing API.

Our new `WorldLocation` model is a data class, similar to `Organisation`.

It:

- fetches "countries" from the Publishing API
- orders the list alphabetically
- caches the responses for performance

[CM-419]: https://gov-uk.atlassian.net/browse/CM-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ