### PR TITLE
(CM-424) Allow user email to be blank

### DIFF
--- a/db/migrate/20250908131107_allow_user_email_to_be_blank.rb
+++ b/db/migrate/20250908131107_allow_user_email_to_be_blank.rb
@@ -1,0 +1,5 @@
+class AllowUserEmailToBeBlank < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :users, :email, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_125525) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_131107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -81,7 +81,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_125525) do
   create_table "users", force: :cascade do |t|
     t.text "name", null: false
     t.text "uid"
-    t.text "email", null: false
+    t.text "email"
     t.boolean "disabled", default: false
     t.boolean "remotely_signed_out", default: false
     t.text "permissions"


### PR DESCRIPTION
In some cases, users will not have an email, so we should make this field optional.