### PR TITLE
Add sentry-sidekiq gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "puma", ">= 5.0"
 gem "rails", "~> 8.0.2", ">= 8.0.2.1"
 gem "record_tag_helper", require: false
 gem "rinku", require: "rails_rinku"
+gem "sentry-sidekiq"
 gem "sprockets-rails"
 gem "terser"
 gem "thruster", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -832,12 +832,15 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (5.26.0)
+    sentry-rails (5.21.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.26.0)
-    sentry-ruby (5.26.0)
+      sentry-ruby (~> 5.21.0)
+    sentry-ruby (5.21.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.21.0)
+      sentry-ruby (~> 5.21.0)
+      sidekiq (>= 3.0)
     sidekiq (7.3.9)
       base64
       connection_pool (>= 2.3.0)
@@ -971,6 +974,7 @@ DEPENDENCIES
   rinku
   rspec-rails
   rubocop-govuk
+  sentry-sidekiq
   simplecov
   sprockets-rails
   terser


### PR DESCRIPTION
This will get rid of the warning:

```
GovukError is not configured to track Sidekiq errors, install the sentry-sidekiq gem to track them.
```

that we’re seeing in the logs