### PR TITLE
(CM-415) Organisation tweaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :test do
   gem "minitest-fail-fast"
   gem "minitest-stub-const"
   gem "mocha"
+  gem "mutex_m"
   gem "rails-controller-testing"
   gem "simplecov"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,7 @@ GEM
     multi_test (1.1.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
+    mutex_m (0.3.0)
     net-http (0.6.0)
       uri
     net-imap (0.5.10)
@@ -962,6 +963,7 @@ DEPENDENCIES
   minitest-fail-fast
   minitest-stub-const
   mocha
+  mutex_m
   pg (~> 1.6)
   pg_search
   plek

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/copy-to-clipboard
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/select-with-search
 //= require govuk_publishing_components/components/tabs
 //= require govuk_publishing_components/lib/cookie-functions
 //= require govuk_publishing_components/lib/trigger-event

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,9 +2,9 @@ class Organisation < Data.define(:id, :name)
   class << self
     def all
       Rails.cache.fetch "organisations", expires_in: 1.day do
-        api_response["results"].map do |organisation|
+        api_response["results"].map { |organisation|
           new(id: organisation["content_id"], name: organisation["title"])
-        end
+        }.sort_by(&:name)
       end
     end
 

--- a/features/step_definitions/content_block_manager_steps.rb
+++ b/features/step_definitions/content_block_manager_steps.rb
@@ -47,7 +47,17 @@ When("I complete the form with the following fields:") do |table|
 
   fill_in "Title", with: @title if @title.present?
 
-  select @organisation, from: "content_block_manager_content_block_edition_lead_organisation_id" if @organisation.present?
+  if @organisation.present?
+    if Capybara.current_session.driver.is_a?(Capybara::Playwright::Driver)
+      Capybara.current_session.driver.with_playwright_page do |page|
+        combobox = page.get_by_role("combobox", name: "Lead organisation")
+        combobox.click
+        combobox.get_by_role("option", name: @organisation).click
+      end
+    else
+      select @organisation, from: "content_block_manager_content_block_edition_lead_organisation_id"
+    end
+  end
 
   fill_in "Instructions to publishers", with: @instructions_to_publishers if @instructions_to_publishers.present?
 

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -12,11 +12,11 @@ class ContentBlockManager::OrganisationTest < ActiveSupport::TestCase
 
   describe "#all" do
     let(:organisation_1) do
-      { "content_id" => SecureRandom.uuid, "title" => "Organisation 1" }
+      { "content_id" => SecureRandom.uuid, "title" => "Organisation B" }
     end
 
     let(:organisation_2) do
-      { "content_id" => SecureRandom.uuid, "title" => "Organisation 2" }
+      { "content_id" => SecureRandom.uuid, "title" => "Organisation A" }
     end
 
     let(:results) do
@@ -36,11 +36,11 @@ class ContentBlockManager::OrganisationTest < ActiveSupport::TestCase
 
       assert_equal 2, organisations.size
 
-      assert_equal organisations.first.id, organisation_1["content_id"]
-      assert_equal organisations.first.name, organisation_1["title"]
+      assert_equal organisations.first.id, organisation_2["content_id"]
+      assert_equal organisations.first.name, organisation_2["title"]
 
-      assert_equal organisations.second.id, organisation_2["content_id"]
-      assert_equal organisations.second.name, organisation_2["title"]
+      assert_equal organisations.second.id, organisation_1["content_id"]
+      assert_equal organisations.second.name, organisation_1["title"]
     end
 
     it "caches results" do


### PR DESCRIPTION
This adds a couple of tweaks for Organisations - firstly, we ensure they are listed alphabetically. Secondly, we add the `select-with-search` JS, so the Organisation list is easier to work with (we already have this in the old CBM, but the lack of Javascript prevented this from working properly)

I also added `mutex_m` to the Gemfile, so I can run the tests in Rubymine.

## Screenshots

### Before

<img width="1208" height="811" alt="image" src="https://github.com/user-attachments/assets/b369e765-928e-48d0-9649-3a47112cd4e2" />

<img width="1212" height="824" alt="image" src="https://github.com/user-attachments/assets/b40ff22d-745a-4934-bdc2-7293787c53c9" />

### After

<img width="1237" height="719" alt="image" src="https://github.com/user-attachments/assets/50c7fab2-a7a8-48db-945a-0f9cb0d5d7fb" />

<img width="1198" height="470" alt="image" src="https://github.com/user-attachments/assets/5ac60eb4-4757-4322-8271-6c0fb04d2394" />
