### PR TITLE
Get rid of frozen string literal warning

### DIFF
--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -12,8 +12,7 @@
   right_to_left ||= false
 
   data_attributes ||= {}
-  data_attributes[:module] ||= ""
-  data_attributes[:module] << " govspeak-editor"
+  data_attributes[:module] = "#{data_attributes[:module]} govspeak-editor"
   data_attributes[:module] = data_attributes[:module].strip
 
   textarea_data_attributes ||= {}


### PR DESCRIPTION
The majority of these warnings were removed by upgrading `govuk_publishing_components` to `60.2.1` here https://github.com/alphagov/content-block-manager/pull/41, but this should remove the remaining warning that’s clogging up our logs.