### PR TITLE
(CM-428) Reset primary key sequence

### DIFF
--- a/lib/content_block_manager/import.rb
+++ b/lib/content_block_manager/import.rb
@@ -20,6 +20,10 @@ module ContentBlockManager
             rows.each do |row|
               klass.create!(**row)
             end
+
+            # As we want the IDs to be the same as the old app - this ensures the next ID is the value of the last
+            # inserted ID plus 1
+            ActiveRecord::Base.connection.reset_pk_sequence!(klass.table_name)
           end
         end
       end


### PR DESCRIPTION
When importing the data, we include the IDs as well. This means that the primary key sequence is now out of whack, and we get an error when creating subsequent rows. This adds a call to the import to reset the primary key sequence using [`reset_pk_sequence!`](https://apidock.com/rails/ActiveRecord/ConnectionAdapters/PostgreSQL/SchemaStatements/reset_pk_sequence%21), which restores the sequence of the table’s primary key to the maximum value.