### PR TITLE
(CM-424) Reset Primary Key sequence of all tables

### DIFF
--- a/lib/content_block_manager/import.rb
+++ b/lib/content_block_manager/import.rb
@@ -20,10 +20,12 @@ module ContentBlockManager
             rows.each do |row|
               klass.create!(**row)
             end
+          end
 
-            # As we want the IDs to be the same as the old app - this ensures the next ID is the value of the last
-            # inserted ID plus 1
-            ActiveRecord::Base.connection.reset_pk_sequence!(klass.table_name)
+          # As we want the IDs to be the same as the old app - this ensures the next ID is the value of the last
+          # inserted ID plus 1
+          ActiveRecord::Base.connection.tables.each do |t|
+            ActiveRecord::Base.connection.reset_pk_sequence!(t)
           end
         end
       end


### PR DESCRIPTION
There are some join tables that get written to that we need to reset the keys of too. To be on the safe side, let’s reset the sequence for all tables, not just the ones for the models we’re acting on