### PR TITLE
(CM-436) Implement GA4

### DIFF
--- a/app/assets/javascripts/domain-config.js
+++ b/app/assets/javascripts/domain-config.js
@@ -6,8 +6,8 @@ window.GOVUK.vars.extraDomains = [
     name: 'production',
     domains: ['content-block-manager.publishing.service.gov.uk'],
     initialiseGA4: true,
-    id: 'GTM-xxx',
-    gaProperty: 'UA-xxx'
+    id: 'GTM-P93SHJ4Z',
+    gaProperty: 'UA-26179049-6'
   },
   {
     name: 'staging',
@@ -18,8 +18,8 @@ window.GOVUK.vars.extraDomains = [
     name: 'integration',
     domains: ['content-block-manager.integration.publishing.service.gov.uk'],
     initialiseGA4: true,
-    id: 'GTM-xxx',
-    auth: 'xxxx',
+    id: 'GTM-P93SHJ4Z',
+    auth: '8jHx-VNEguw67iX9TBC6_g',
     preview: 'env-50'
   }
 ]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,8 @@ class User < ApplicationRecord
   module Permissions
     SIGNIN = "signin".freeze
   end
+
+  def organisation
+    organisation_content_id ? Organisation.find(organisation_content_id) : nil
+  end
 end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -7,7 +7,7 @@
     <meta name="govuk:user-organisation-name" content="<%= current_user&.organisation&.name %>">
     <meta name="govuk:user-role" content="<%= current_user&.role %>">
     <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
-    <meta name="govuk:user-id" content="">
+    <meta name="govuk:user-id" content="<%= current_user&.anonymous_user_id %>">
     <% if get_content_id(@edition) %>
       <meta name="govuk:content-id" content="<%= get_content_id(@edition) %>">
     <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -4,7 +4,7 @@
   <% content_for :head do %>
     <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
     <meta name="govuk:user-created-at" content="<%= current_user&.created_at&.to_date %>">
-    <meta name="govuk:user-organisation-name" content="<%#= current_user&.organisation_name %>">
+    <meta name="govuk:user-organisation-name" content="<%= current_user&.organisation&.name %>">
     <meta name="govuk:user-role" content="<%= current_user&.role %>">
     <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
     <meta name="govuk:user-id" content="">

--- a/test/unit/app/models/user_test.rb
+++ b/test/unit/app/models/user_test.rb
@@ -29,4 +29,21 @@ class ContentBlockManager::UserTest < ActiveSupport::TestCase
       assert_equal "Editor", user.role
     end
   end
+
+  describe "#organisation" do
+    it "returns nil when organisation_content_id is nil" do
+      user = build(:user)
+
+      assert_nil user.organisation
+    end
+
+    it "returns an organisation when one exists" do
+      organisation = build(:organisation, id: SecureRandom.uuid)
+      user = build(:user, organisation_content_id: organisation.id)
+
+      Organisation.expects(:find).with(organisation.id).returns(organisation)
+
+      assert_equal user.organisation, organisation
+    end
+  end
 end


### PR DESCRIPTION
This adds the relevant bits and pieces to allow us to send analytics information to GA4, as well as adding some meta tags to send richer information.