### PR TITLE
Fix content block edition factory to respect explicit document_id

### DIFF
--- a/test/factories/edition.rb
+++ b/test/factories/edition.rb
@@ -24,7 +24,11 @@ FactoryBot.define do
 
     Schema.valid_schemas.each do |type|
       trait type.to_sym do
-        document { build(:document, block_type: type) }
+        after(:build) do |edition, _evaluator|
+          unless edition.document_id || edition.document
+            edition.document = build(:document, block_type: type)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This fix was [applied in Whitehall](https://github.com/alphagov/whitehall/pull/10652) as an upgrade to `factory_bot` caused some issues. We haven’t seen them happen here, but for consistency (and also to prevent any issues that might happen), we’ll apply it here.