### PR TITLE
(CM-479) Ignore `order` field

### DIFF
--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -100,7 +100,11 @@ class Schema
 private
 
   def field_names
-    sort_fields (@body["properties"].to_a - embedded_objects.to_a).to_h.keys
+    sort_fields @body["properties"].keys - properties_to_ignore
+  end
+
+  def properties_to_ignore
+    [*embedded_objects.keys, "order"]
   end
 
   def sort_fields(fields)

--- a/test/unit/app/models/schema_test.rb
+++ b/test/unit/app/models/schema_test.rb
@@ -119,6 +119,27 @@ class SchemaTest < ActiveSupport::TestCase
     end
   end
 
+  describe "when a schema includes an order property" do
+    let(:body) do
+      {
+        "properties" => {
+          "foo" => {
+            "type" => "string",
+          },
+          "order" => {
+            "type" => "array",
+          },
+        },
+      }
+    end
+
+    describe "#fields" do
+      it "excludes the order field" do
+        assert_equal schema.fields.map(&:name), %w[foo]
+      end
+    end
+  end
+
   describe ".permitted_params" do
     it "returns permitted params" do
       assert_equal schema.permitted_params, %w[title foo bar]


### PR DESCRIPTION
This is a new field that we intend to add for contact blocks. This will be populated on a different screen, so we need to ensure that it is ignored when populating the form on the initial screen.