### PR TITLE
CM-480 Declare "govspeak-enabled" in config rather than schema

### DIFF
--- a/app/models/schema/embedded_schema.rb
+++ b/app/models/schema/embedded_schema.rb
@@ -1,6 +1,6 @@
 class Schema
   class EmbeddedSchema < Schema
-    GOVSPEAK_ENABLED_PROPERTY_KEY = "x-govspeak_enabled".freeze
+    GOVSPEAK_ENABLED_PROPERTY_KEY = "govspeak_enabled".freeze
 
     def initialize(id, body, parent_schema_id)
       @parent_schema_id = parent_schema_id
@@ -41,17 +41,17 @@ class Schema
     end
 
     def govspeak_enabled?(field_name:, nested_object_key: nil)
-      return top_level_govspeak_enabled_fields.include?(field_name) unless nested_object_key
+      return top_level_govspeak_enabled_field?(field_name) unless nested_object_key
 
-      govspeak_enabled_fields_for_nested_object(nested_object_key).include?(field_name)
+      govspeak_enabled_field_for_nested_object?(nested_object_key, field_name)
     end
 
-    def govspeak_enabled_fields_for_nested_object(object_key)
-      body.dig("properties", object_key, GOVSPEAK_ENABLED_PROPERTY_KEY) || []
+    def govspeak_enabled_field_for_nested_object?(object_key, field_name)
+      config.dig("fields", object_key, "fields", field_name, GOVSPEAK_ENABLED_PROPERTY_KEY) == true
     end
 
-    def top_level_govspeak_enabled_fields
-      body.dig("properties", GOVSPEAK_ENABLED_PROPERTY_KEY) || []
+    def top_level_govspeak_enabled_field?(field_name)
+      config.dig("fields", field_name, GOVSPEAK_ENABLED_PROPERTY_KEY) == true
     end
 
   private

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -75,9 +75,15 @@ schemas:
           bsl_guidance:
             component:
               bsl_guidance
+            fields:
+              value:
+                govspeak_enabled: true
           video_relay_service:
             component:
               video_relay_service
+            fields:
+              prefix:
+                govspeak_enabled: true
           telephone_numbers:
             data_attributes:
               module: auto-populate-telephone-number-label

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -96,8 +96,7 @@ Feature: Create a contact object
               "type": "string",
               "default": "0800 123 4567"
             }
-          },
-          "x-govspeak_enabled": ["prefix"]
+          }
         },
         "call_charges": {
           "type": "object",

--- a/test/components/edition/details/fields/govspeak_enabled_textarea_component_test.rb
+++ b/test/components/edition/details/fields/govspeak_enabled_textarea_component_test.rb
@@ -7,21 +7,13 @@ class Edition::Details::Fields::GovspeakEnabledTextareaComponentTest < ViewCompo
 
   let(:edition) { build(:edition, :contact) }
 
-  let(:properties) do
-    {
-      "video_relay_service" => {
-        "x-govspeak_enabled" => %w[prefix],
-      },
-    }
-  end
-
   let(:body) do
     {
       "type" => "object",
       "patternProperties" => {
         "*" => {
           "type" => "object",
-          "properties" => properties,
+          "properties" => {},
         },
       },
     }
@@ -33,6 +25,25 @@ class Edition::Details::Fields::GovspeakEnabledTextareaComponentTest < ViewCompo
       body,
       "parent_schema_id",
     )
+  end
+  let(:config) do
+    {
+      "schemas" => {
+        "parent_schema_id" => {
+          "subschemas" => {
+            "telephones" => {
+              "fields" => {
+                "video_relay_service" => {
+                  "fields" => {
+                    "prefix" => { "govspeak_enabled" => true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
   end
 
   let(:field) do
@@ -61,6 +72,10 @@ class Edition::Details::Fields::GovspeakEnabledTextareaComponentTest < ViewCompo
       "edition.details.labels.telephones.video_relay_service.prefix",
       default: "Prefix",
     ).returns("Translated label")
+
+    Schema::EmbeddedSchema
+      .stubs(:schema_settings)
+      .returns(config)
   end
 
   describe "GovspeakEnabledTextareaComponent" do
@@ -149,11 +164,23 @@ class Edition::Details::Fields::GovspeakEnabledTextareaComponentTest < ViewCompo
     end
 
     describe "'Govspeak supported' indicator" do
-      context "when the field IS declared 'govspeak-enabled' in the subschema" do
-        let(:properties) do
+      context "when the field IS declared 'govspeak-enabled' in the config" do
+        let(:config) do
           {
-            "video_relay_service" => {
-              "x-govspeak_enabled" => %w[prefix],
+            "schemas" => {
+              "parent_schema_id" => {
+                "subschemas" => {
+                  "telephones" => {
+                    "fields" => {
+                      "video_relay_service" => {
+                        "fields" => {
+                          "prefix" => { "govspeak_enabled" => true },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           }
         end
@@ -228,11 +255,23 @@ class Edition::Details::Fields::GovspeakEnabledTextareaComponentTest < ViewCompo
         end
       end
 
-      context "when the field is NOT declared 'govspeak-enabled in the subschema" do
-        let(:properties) do
+      context "when the field is NOT declared 'govspeak-enabled in the config" do
+        let(:config) do
           {
-            "video_relay_service" => {
-              "x-govspeak_enabled" => [],
+            "schemas" => {
+              "parent_schema_id" => {
+                "subschemas" => {
+                  "telephones" => {
+                    "fields" => {
+                      "video_relay_service" => {
+                        "fields" => {
+                          "prefix" => {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           }
         end

--- a/test/unit/app/models/schema/embedded_schema_test.rb
+++ b/test/unit/app/models/schema/embedded_schema_test.rb
@@ -286,30 +286,49 @@ class Schema::EmbeddedSchemaTest < ActiveSupport::TestCase
         "patternProperties" => {
           "*" => {
             "type" => "object",
-            "properties" => {
-              "field_1" => { "type" => "string" },
-              "field_2" => { "type" => "string" },
-              "x-govspeak_enabled" => %w[field_2],
-              "nested_object_1" => {
-                "type" => "object",
-                "properties" => {
-                  "field_1" => { "type" => "string" },
-                  "field_2" => { "type" => "string" },
+            "properties" => {},
+          },
+        },
+      }
+    end
+
+    let(:subschema_id) { "subschema_id" }
+    let(:parent_schema_id) { "parent_schema_id" }
+    let(:schema) { Schema::EmbeddedSchema.new(subschema_id, body, parent_schema_id) }
+
+    let(:config) do
+      {
+        "schemas" => {
+          parent_schema_id => {
+            "subschemas" => {
+              subschema_id => {
+                "fields" => {
+                  "field_1" => {},
+                  "field_2" => { "govspeak_enabled" => true },
+                  "nested_object_1" => {
+                    "fields" => {
+                      "field_1" => {},
+                      "field_2" => { "govspeak_enabled" => true },
+                    },
+                  },
+                  "nested_object_2" => {
+                    "fields" => {
+                      "field_1" => { "govspeak_enabled" => true },
+                      "field_2" => {},
+                    },
+                  },
                 },
-                "x-govspeak_enabled" => %w[field_2],
-              },
-              "nested_object_2" => {
-                "type" => "object",
-                "properties" => {
-                  "field_1" => { "type" => "string" },
-                  "field_2" => { "type" => "string" },
-                },
-                "x-govspeak_enabled" => %w[field_1],
               },
             },
           },
         },
       }
+    end
+
+    before do
+      Schema::EmbeddedSchema
+        .stubs(:schema_settings)
+        .returns(config)
     end
 
     context "when a nested_object_key is given" do


### PR DESCRIPTION
See Jira [CM-480](https://gov-uk.atlassian.net/browse/CM-480)

This is a step in the process of making all fields which should be "Govspeak-enabled" have the expected behaviour:

- informative note that "Govspeak supported"
- ability to toggle between "edit" and "preview" modes 

In this PR we move the existing declarations of "govspeak enabled" from schema to config. There are just two at present, on nested objects within a the "telephones" subschema:

- `telephones.video_relay_service.prefix`
- `telephones.bsl_guidance.value`

NB: we need to remove the custom `x-govspeak-enabled` property from the JSON schema in Publishing API