### PR TITLE
Don’t render a link when Host Edition has no base_path

### DIFF
--- a/app/components/document/show/host_editions_table_component.rb
+++ b/app/components/document/show/host_editions_table_component.rb
@@ -108,6 +108,8 @@ private
   end
 
   def frontend_path(content_item)
+    return nil if content_item.base_path.nil?
+
     Plek.website_root + content_item.base_path
   end
 
@@ -125,8 +127,13 @@ private
   end
 
   def content_link(content_item)
-    link_to(content_link_text(content_item),
-            frontend_path(content_item), class: "govuk-link", target: "_blank", rel: "noopener")
+    path = frontend_path(content_item)
+
+    if path
+      link_to(content_link_text(content_item), path, class: "govuk-link", target: "_blank", rel: "noopener")
+    else
+      content_item.title
+    end
   end
 
   def updated_field_for(content_item)

--- a/test/components/document/show/host_editions_table_component_test.rb
+++ b/test/components/document/show/host_editions_table_component_test.rb
@@ -144,6 +144,38 @@ class Document::Show::HostEditionsTableComponentTest < ViewComponent::TestCase
       end
     end
 
+    describe "when a base_path is nil" do
+      let(:host_content_item) do
+        HostContentItem.new(
+          "title" => "Some title",
+          "base_path" => nil,
+          "document_type" => "document_type",
+          "publishing_app" => "publisher",
+          "last_edited_by_editor" => last_edited_by_editor,
+          "last_edited_at" => Time.zone.now.to_s,
+          "publishing_organisation" => publishing_organisation,
+          "unique_pageviews" => unique_pageviews,
+          "host_content_id" => SecureRandom.uuid,
+          "host_locale" => "en",
+          "instances" => 1,
+        )
+      end
+
+      it "Does not render a link" do
+        render_inline(
+          described_class.new(
+            caption:,
+            host_content_items:,
+            edition:,
+          ),
+        )
+
+        assert_selector "tbody" do |tbody|
+          tbody.assert_no_selector ".govuk-link", text: "#{host_content_item.title} (opens in new tab)"
+        end
+      end
+    end
+
     describe "sorting headers" do
       it "adds the table header as an anchor tag to each header" do
         render_inline(


### PR DESCRIPTION
We recently saw an error when embeddding a content block within another content block, as content block’s don’t have a base_path. We don’t expect this to happen in real life too much, but let’s add a guard in case someone does it.