### PR TITLE
(CM-125) Bump Content Block Tools

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
-    content_block_tools (1.2.3)
+    content_block_tools (1.3.0)
       actionview (>= 6, < 8.0.3)
       govspeak (>= 10.6.3)
       rails (>= 6, < 8.0.3)


### PR DESCRIPTION
As Dependabot is disabled (for now), we need to do this manually.