### PR TITLE
Add custom error pages

### DIFF
--- a/app/controllers/editions/embedded_objects_controller.rb
+++ b/app/controllers/editions/embedded_objects_controller.rb
@@ -22,7 +22,7 @@ class Editions::EmbeddedObjectsController < BaseController
       @context = @edition.title
 
       if @subschemas.blank?
-        render "admin/errors/not_found", status: :not_found
+        render "errors/not_found", status: :not_found
       else
         render "shared/embedded_objects/select_subschema"
       end
@@ -55,7 +55,7 @@ class Editions::EmbeddedObjectsController < BaseController
     @object_title = params[:object_title]
     @object = @edition.details.dig(params[:object_type], params[:object_title])
 
-    render "admin/errors/not_found", status: :not_found unless @object
+    render "errors/not_found", status: :not_found unless @object
   end
 
   def update

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,21 @@
+class ErrorsController < ApplicationController
+  def bad_request
+    render(status: :bad_request)
+  end
+
+  def forbidden
+    render(status: :forbidden)
+  end
+
+  def not_found
+    render(status: :not_found)
+  end
+
+  def unprocessable_content
+    render(status: :unprocessable_content)
+  end
+
+  def internal_server_error
+    render(status: :internal_server_error)
+  end
+end

--- a/app/views/errors/bad_request.html.erb
+++ b/app/views/errors/bad_request.html.erb
@@ -1,4 +1,3 @@
-<% content_for :product_name, ContentBlockManager.product_name %>
 <% content_for :page_title, "Something went wrong" %>
 <% content_for :title, "Something went wrong" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/app/views/errors/down_for_maintenance.html.erb
+++ b/app/views/errors/down_for_maintenance.html.erb
@@ -1,4 +1,3 @@
-<% content_for :product_name, ContentBlockManager.product_name %>
 <% content_for :page_title, "Down for maintenance" %>
 <% content_for :title, "Down for maintenance" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,4 +1,3 @@
-<% content_for :product_name, ContentBlockManager.product_name %>
 <% content_for :page_title, "Permissions error" %>
 <% content_for :title, "Permissions error" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,4 +1,3 @@
-<% content_for :product_name, ContentBlockManager.product_name %>
 <% content_for :page_title, "Server error" %>
 <% content_for :title, "Server error" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,4 +1,3 @@
-<% content_for :product_name, ContentBlockManager.product_name %>
 <% content_for :page_title, "There is a mistake in the URL" %>
 <% content_for :title, "There is a mistake in the URL" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/app/views/errors/unprocessable_content.html.erb
+++ b/app/views/errors/unprocessable_content.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, "Something went wrong" %>
+<% content_for :title, "Something went wrong" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-0">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Please try again by selecting the browser&rsquo;s back button or <%= link_to "raise a support request", ContentBlockManager.support_url, class: "govuk-link govuk-link--no-visited-state" %>.</p>
+  </div>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,4 +1,3 @@
-<% content_for :product_name, ContentBlockManager.product_name %>
 <% content_for :page_title, "Something went wrong" %>
 <% content_for :title, "Something went wrong" %>
 <% content_for :title_margin_bottom, 6 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,9 @@ module ContentBlockManager
     # when a translation is present
     config.active_model.i18n_customize_full_message = true
 
+    # Serve error pages from app instead of static pages
+    config.exceptions_app = routes
+
     config.eager_load_paths += %W[
       #{config.root}/lib
     ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,14 @@ Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 
+  scope via: :all do
+    match "/400", to: "errors#bad_request"
+    match "/403", to: "errors#forbidden"
+    match "/404", to: "errors#not_found"
+    match "/422", to: "errors#unprocessable_content"
+    match "/500", to: "errors#internal_server_error"
+  end
+
   namespace :admin do
     post "preview" => "preview#preview"
   end

--- a/test/integration/errors_test.rb
+++ b/test/integration/errors_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require "capybara/rails"
+
+class Admin::ErrorsControllerTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+  extend Minitest::Spec::DSL
+
+  setup do
+    login_as_admin
+  end
+
+  ERROR_LOOKUPS = {
+    "400": :bad_request,
+    "403": :forbidden,
+    "404": :not_found,
+    "422": :unprocessable_content,
+    "500": :internal_server_error,
+  }.freeze
+
+  ERROR_LOOKUPS.each do |error_code, error|
+    it "should show the #{error} page" do
+      get "/#{error_code}"
+
+      assert_template error
+    end
+  end
+end


### PR DESCRIPTION
This adds custom error pages by setting `config.exceptions_app` to `routes`, as well as setting up the routes.

We already had the error views in the app from the migration, but I’ve removed the setting of the `product_name`, which isn’t necessary, as well as adding a view from the `unprocessable_content` error, which wasn’t there

I've also moved the views out of the `admin` namespace, which we don't make use of.