### PR TITLE
CM-484: Move 'Govspeak supported' guidance out of hint element

### DIFF
--- a/app/components/edition/details/fields/textarea_component.html.erb
+++ b/app/components/edition/details/fields/textarea_component.html.erb
@@ -9,6 +9,9 @@
                 hint_id: aria_described_by,
                 rows: 5,
     } %>
+    <p class="govuk-body guidance govspeak-supported govuk-hint govuk-!-margin-top-2 govuk-!-margin-bottom-5">
+      Govspeak supported
+    </p>
   <% else %>
     <%= render "govuk_publishing_components/components/textarea", {
                 label: { text: label_element },

--- a/app/components/edition/details/fields/textarea_component.rb
+++ b/app/components/edition/details/fields/textarea_component.rb
@@ -32,9 +32,7 @@ class Edition::Details::Fields::TextareaComponent < Edition::Details::Fields::Ba
   end
 
   def hint_text
-    return nil unless govspeak_enabled?
-
-    "Govspeak supported"
+    nil
   end
 
   def aria_described_by

--- a/test/components/edition/details/fields/textarea_component_test.rb
+++ b/test/components/edition/details/fields/textarea_component_test.rb
@@ -185,7 +185,7 @@ class Edition::Details::Fields::TextareaComponentTest < ViewComponent::TestCase
           }
         end
 
-        it "displays a 'Govspeak supported' hint" do
+        it "displays guidance to indicate 'Govspeak supported'" do
           render_inline component
 
           assert_selector(COMPONENT_CLASS) do |component|
@@ -206,16 +206,6 @@ class Edition::Details::Fields::TextareaComponentTest < ViewComponent::TestCase
             assert_selector(COMPONENT_CLASS) do |component|
               component.assert_selector(
                 "textarea[aria-describedby='#{expected_hint_id_to_aria_mapping}']",
-              )
-            end
-          end
-
-          it "includes an ID on the label hint div, matching the 'aria-describedby' on the textarea" do
-            render_inline component
-
-            assert_selector(COMPONENT_CLASS) do |component|
-              component.assert_selector(
-                "div.govuk-hint[id='#{expected_hint_id_to_aria_mapping}']",
               )
             end
           end
@@ -361,14 +351,14 @@ class Edition::Details::Fields::TextareaComponentTest < ViewComponent::TestCase
 
   def displays_indication_that_govspeak_is_supported(component)
     component.assert_selector(
-      ".govuk-hint",
+      ".guidance.govspeak-supported",
       text: "Govspeak supported",
     )
   end
 
   def displays_no_indication_that_govspeak_is_supported(component)
     component.assert_no_selector(
-      ".govuk-hint",
+      ".guidance",
       text: "Govspeak supported",
     )
   end


### PR DESCRIPTION
Jira [CM-484](https://gov-uk.atlassian.net/browse/CM-484)

We will be offering specific guidance for numerous fields using the "hint" element. We move the "Govspeak supported" note into a "guidance" element under the textarea.

## Before

<img width="1291" height="368" alt="govspeak_supported_msg_before" src="https://github.com/user-attachments/assets/26611d71-14bd-44c9-9e28-9260726783b3" />

## After

<img width="1210" height="416" alt="govspeak_supported_relocated_2" src="https://github.com/user-attachments/assets/a59f42a4-00a6-4c46-801f-48bd33afbee5" />



[CM-484]: https://gov-uk.atlassian.net/browse/CM-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ