### PR TITLE
Don’t load test tasks in production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,23 +2,24 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative "config/application"
-
-require "minitest/test_task"
-require "cucumber/rake/task"
-# We only set this var when running via Rake, so that we can get
-# sensible coverage reports when running a full test suite,
-# without overwriting them when we're just running a single test
-ENV["COVERAGE"] = "true"
-
 Rails.application.load_tasks
 
-Minitest::TestTask.create do |t|
-  t.test_globs = %w[test/**/*_test.rb]
-end
+unless Rails.env.production?
+  require "minitest/test_task"
+  require "cucumber/rake/task"
+  # We only set this var when running via Rake, so that we can get
+  # sensible coverage reports when running a full test suite,
+  # without overwriting them when we're just running a single test
+  ENV["COVERAGE"] = "true"
 
-Cucumber::Rake::Task.new(:cucumber) do |t|
-  t.cucumber_opts = "--format pretty" # Any valid command line option can go here.
-end
+  Minitest::TestTask.create do |t|
+    t.test_globs = %w[test/**/*_test.rb]
+  end
 
-Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint test cucumber]
+  Cucumber::Rake::Task.new(:cucumber) do |t|
+    t.cucumber_opts = "--format pretty" # Any valid command line option can go here.
+  end
+
+  Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+  task default: %i[lint test cucumber]
+end


### PR DESCRIPTION
When building the container in production (i.e when building the app for deployment), we get the error:

```
LoadError: cannot load such file -- cucumber/rake/task (LoadError)
```

This wraps our test-related Rakefile stuff inside an `Rails.env.production?` check so we only load the test rake tasks in non-prod environments.