### PR TITLE
CM-483: add govspeak-enabled behaviour to Schema

### DIFF
--- a/app/components/edition/details/fields/opening_hours_component.html.erb
+++ b/app/components/edition/details/fields/opening_hours_component.html.erb
@@ -1,5 +1,18 @@
 <input type="hidden" name="<%= name_for_field(show_opening_hours) %>" value="false">
 
+<% textarea = capture do %>
+  <%= render(
+    Edition::Details::Fields::TextareaComponent.new(
+      edition: edition,
+      value: value_for_field(opening_hours) ,
+      nested_object_key: field.name,
+      field: opening_hours,
+      schema: schema,
+      subschema: subschema,
+    ),
+  ) %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: name_for_field(show_opening_hours),
   id: id_for_field(show_opening_hours),
@@ -13,15 +26,7 @@
       label: label_for("show_opening_hours"),
       value: "true",
       checked: value_for_field(show_opening_hours) == true,
-      conditional: capture do
-        render("govuk_publishing_components/components/textarea", {
-          label: { text: label_for("opening_hours") },
-          name: name_for_field(opening_hours) ,
-          id: id_for_field(opening_hours),
-          value: value_for_field(opening_hours),
-          error_items: errors_for_field(opening_hours),
-        })
-      end,
+      conditional: textarea,
     },
   ],
 } %>

--- a/app/components/edition/details/fields/textarea_component.rb
+++ b/app/components/edition/details/fields/textarea_component.rb
@@ -5,12 +5,17 @@ class Edition::Details::Fields::TextareaComponent < Edition::Details::Fields::Ba
     super(**args)
   end
 
-  attr_reader :edition, :nested_object_key, :field, :subschema, :errors
+  attr_reader :edition, :nested_object_key, :field, :schema, :subschema, :errors
 
   def govspeak_enabled?
-    return false unless nested_object_key
+    if nested_object_key
+      return subschema.govspeak_enabled?(
+        nested_object_key: nested_object_key,
+        field_name: field.name,
+      )
+    end
 
-    subschema.govspeak_enabled?(nested_object_key: nested_object_key, field_name: field.name)
+    schema.govspeak_enabled?(field_name: field.name)
   end
 
   def name_attribute

--- a/app/components/edition/details/fields/video_relay_service_component.html.erb
+++ b/app/components/edition/details/fields/video_relay_service_component.html.erb
@@ -7,7 +7,7 @@
         value: value_for_field(prefix) ,
         nested_object_key: field.name,
         field: prefix,
-        schema:,
+        schema: schema,
         subschema: subschema,
       ),
     ) %>

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -6,6 +6,8 @@ class Schema
 
   CONFIG_PATH = Rails.root.join("config/content_block_manager.yml").to_s
 
+  GOVSPEAK_ENABLED_PROPERTY_KEY = "govspeak_enabled".freeze
+
   class << self
     def valid_schemas
       Flipflop.show_all_content_block_types? ? VALID_SCHEMAS : %w[pension]

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -85,6 +85,10 @@ class Schema
     @config ||= self.class.schema_settings.dig("schemas", @id) || {}
   end
 
+  def govspeak_enabled?(field_name:)
+    config.dig("fields", field_name, GOVSPEAK_ENABLED_PROPERTY_KEY) == true
+  end
+
   def field_ordering_rule(field)
     if field_order
       # If a field order is found in the config, order by the index. If a field is not found, put it to the end

--- a/app/models/schema/embedded_schema.rb
+++ b/app/models/schema/embedded_schema.rb
@@ -1,7 +1,5 @@
 class Schema
   class EmbeddedSchema < Schema
-    GOVSPEAK_ENABLED_PROPERTY_KEY = "govspeak_enabled".freeze
-
     def initialize(id, body, parent_schema_id)
       @parent_schema_id = parent_schema_id
       body = body["patternProperties"]&.values&.first || raise(ArgumentError, "Subschema `#{id}` is invalid")
@@ -47,11 +45,11 @@ class Schema
     end
 
     def govspeak_enabled_field_for_nested_object?(object_key, field_name)
-      config.dig("fields", object_key, "fields", field_name, GOVSPEAK_ENABLED_PROPERTY_KEY) == true
+      config.dig("fields", object_key, "fields", field_name, Schema::GOVSPEAK_ENABLED_PROPERTY_KEY) == true
     end
 
     def top_level_govspeak_enabled_field?(field_name)
-      config.dig("fields", field_name, GOVSPEAK_ENABLED_PROPERTY_KEY) == true
+      config.dig("fields", field_name, Schema::GOVSPEAK_ENABLED_PROPERTY_KEY) == true
     end
 
   private

--- a/app/views/editions/workflow/group_objects.html.erb
+++ b/app/views/editions/workflow/group_objects.html.erb
@@ -12,6 +12,7 @@
     <%= render("govuk_publishing_components/components/button", {
       text: "Preview",
       secondary_quiet: true,
+      title: "Preview block",
       href: preview_edition_path(@edition),
       margin_bottom: false,
       data_attributes: {

--- a/app/views/shared/embedded_objects/select_subschema.html.erb
+++ b/app/views/shared/embedded_objects/select_subschema.html.erb
@@ -12,6 +12,7 @@
     <%= render("govuk_publishing_components/components/button", {
       text: "Preview",
       secondary_quiet: true,
+      title: "Preview block",
       href: preview_edition_path(@edition),
       margin_bottom: false,
       data_attributes: {

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -123,6 +123,7 @@ schemas:
           description:
             component:
               textarea
+            govspeak_enabled: true
       contact_links:
         group: contact_methods
         embeddable_as_block: true

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -66,6 +66,7 @@ schemas:
           description:
             component:
               textarea
+            govspeak_enabled: true
           opening_hours:
             component:
               opening_hours

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -23,6 +23,8 @@ schemas:
       description:
         component:
           textarea
+        govspeak_enabled: true
+
     subschemas:
       email_addresses:
         group: contact_methods

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -69,6 +69,9 @@ schemas:
           opening_hours:
             component:
               opening_hours
+            fields:
+              opening_hours:
+                govspeak_enabled: true
           call_charges:
             component:
               call_charges

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -44,6 +44,7 @@ schemas:
           description:
             component:
               textarea
+            govspeak_enabled: true
       telephones:
         group: contact_methods
         group_order: 2

--- a/features/step_definitions/preview_block_steps.rb
+++ b/features/step_definitions/preview_block_steps.rb
@@ -1,5 +1,5 @@
 When(/^I click on Preview$/) do
-  click_on "Preview"
+  preview_block_button.click
 end
 
 Then(/^I should see a preview of my contact$/) do
@@ -16,4 +16,8 @@ Then(/^I should see the add contact methods screen$/) do
   within ".govuk-summary-card" do
     @details["title"]
   end
+end
+
+def preview_block_button
+  find("a[title='Preview block']", text: "Preview")
 end

--- a/test/components/edition/details/fields/opening_hours_component_test.rb
+++ b/test/components/edition/details/fields/opening_hours_component_test.rb
@@ -5,24 +5,48 @@ class Edition::Details::Fields::OpeningHoursComponentTest < BaseComponentTestCla
 
   let(:edition) { build(:edition, :contact) }
 
-  let(:body) do
+  let(:properties) do
     {
-      "type" => "object",
-      "properties" =>
-        { "opening_hours" =>
-            { "type" => "object",
-              "properties" =>
-                { "opening_hours" => { "type" => "string" },
-                  "show_opening_hours" => { "type" => "boolean" } } } },
+      "opening_hours" => {
+        "type" => "object",
+        "properties" => {
+          "show_opening_hours" => {
+            "type" => "boolean", "default" => false
+          },
+          "opening_hours" => {
+            "type" => "string",
+          },
+        },
+      },
     }
   end
 
-  let(:schema) { stub(:schema, block_type: "schema", body:) }
+  let(:body) do
+    {
+      "type" => "object",
+      "patternProperties" => {
+        "*" => {
+          "type" => "object",
+          "properties" => properties,
+        },
+      },
+    }
+  end
+
+  let(:subschema) do
+    Schema::EmbeddedSchema.new(
+      "telephones",
+      body,
+      "parent_schema_id",
+    )
+  end
+
+  let(:schema) { stub(:schema, block_type: "schema") }
 
   let(:field) do
     Schema::Field.new(
       "opening_hours",
-      schema,
+      subschema,
     )
   end
 
@@ -36,7 +60,8 @@ class Edition::Details::Fields::OpeningHoursComponentTest < BaseComponentTestCla
       edition:,
       field: field,
       value: field_value,
-      schema:,
+      schema: schema,
+      subschema: subschema,
     )
   end
 
@@ -96,7 +121,7 @@ class Edition::Details::Fields::OpeningHoursComponentTest < BaseComponentTestCla
           assert_selector(".govuk-checkboxes") do |component|
             component.assert_selector(
               "textarea" \
-                "[name='edition[details][opening_hours][opening_hours]']",
+                "[name='edition[details][telephones][opening_hours][opening_hours]']",
               text: "CUSTOM VALUE",
             )
           end

--- a/test/components/edition/details/fields/textarea_component_test.rb
+++ b/test/components/edition/details/fields/textarea_component_test.rb
@@ -7,6 +7,301 @@ class Edition::Details::Fields::TextareaComponentTest < BaseComponentTestClass
 
   let(:edition) { build(:edition, :contact) }
 
+  context "when textarea is built for a schema" do
+    let(:properties) do
+      {
+        "rich_field" => { "type" => "string" },
+        "plain_field" => { "type" => "string" },
+      }
+    end
+
+    let(:body) do
+      {
+        "type" => "object",
+        "properties" => properties,
+      }
+    end
+
+    let(:schema_id) { "content_block_contact" }
+
+    let(:config) do
+      {
+        "schemas" => {
+          schema_id => {
+            "fields" => {
+              "rich_field" => {
+                "component" => "textarea",
+                "govspeak_enabled" => true,
+              },
+              "plain_field" => {
+                "component" => "textarea",
+              },
+            },
+          },
+        },
+      }
+    end
+
+    let(:schema) { Schema.new(schema_id, body) }
+
+    let(:rich_field) do
+      Schema::Field.new(
+        "rich_field",
+        schema,
+      )
+    end
+
+    let(:plain_field) do
+      Schema::Field.new(
+        "plain_field",
+        schema,
+      )
+    end
+
+    let(:field_value) { nil }
+
+    let(:component) do
+      described_class.new(
+        edition: edition,
+        field: rich_field,
+        schema: schema,
+        value: field_value,
+      )
+    end
+
+    before do
+      Schema
+        .stubs(:schema_settings)
+        .returns(config)
+    end
+
+    it "gives the textarea an ID describing path to field" do
+      render_inline component
+
+      assert_selector(COMPONENT_CLASS) do |component|
+        expected_id = "edition_details_rich_field"
+
+        component.assert_selector(
+          "textarea[id='#{expected_id}']",
+        )
+      end
+    end
+
+    it "includes a translated _label_" do
+      render_inline component
+
+      assert_selector(COMPONENT_CLASS) do |component|
+        displays_label_using_translation_system(component)
+      end
+    end
+
+    it "includes a _name_ attribute representing nested field location" do
+      render_inline component
+
+      assert_selector(COMPONENT_CLASS) do |component|
+        expected_name_attribute =
+          "edition[details][rich_field]"
+
+        component.assert_selector(
+          "textarea[name='#{expected_name_attribute}']",
+        )
+      end
+    end
+
+    describe "default value" do
+      let(:properties) do
+        {
+          "rich_field" => { "type" => "string", "default" => "**Rich** field" },
+          "plain_field" => { "type" => "string" },
+        }
+      end
+
+      context "when there is NO value set for the textarea" do
+        let(:field_value) { nil }
+
+        it "supplies the default value defined in the schema" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_selector(
+              "textarea",
+              text: "**Rich** field",
+            )
+          end
+        end
+      end
+
+      context "when there IS a value set for the textarea" do
+        let(:field_value) {  "Field value *set*" }
+
+        it "displays that value" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            shows_set_value_in_textarea(component, "Field value *set*")
+          end
+        end
+      end
+
+      describe "error handling" do
+        context "when there is an error on the field" do
+          before do
+            edition.errors.add(
+              :details_rich_field,
+              "blank",
+            )
+
+            I18n.expects(:t).with(
+              "activerecord.errors.models.edition" \
+                ".attributes.details_rich_field.format".to_sym,
+              has_entry(message: "blank"),
+            ).returns("Rich field must be present")
+          end
+
+          it "adds an error class to the form group to highlight the area needing attention" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(".govuk-form-group.govuk-form-group--error")
+            end
+          end
+
+          it "adds an error message to clarify the error and remedial action required" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                ".govuk-error-message",
+                text: "Rich field must be present",
+              )
+            end
+          end
+        end
+      end
+    end
+    describe "'Govspeak supported' indicator" do
+      context "when the field IS declared 'govspeak-enabled' in the config" do
+        let(:component) do
+          described_class.new(
+            edition: edition,
+            field: rich_field,
+            schema: schema,
+            value: field_value,
+          )
+        end
+
+        it "displays guidance to indicate 'Govspeak supported'" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            displays_indication_that_govspeak_is_supported(component)
+          end
+        end
+
+        describe "hint ID mapping to textarea 'aria-describedby'" do
+          let(:expected_hint_id_to_aria_mapping) do
+            "edition_details_rich_field-hint"
+          end
+
+          it "includes an 'aria-describedby' attribute on the textarea, to match the label hint's ID" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "textarea[aria-describedby='#{expected_hint_id_to_aria_mapping}']",
+              )
+            end
+          end
+
+          it "includes a 'Preview' button" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "button.js-app-c-govspeak-editor__preview-button",
+                text: "Preview",
+              )
+            end
+          end
+
+          it "includes a 'Back to edit' button" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "button.js-app-c-govspeak-editor__back-button",
+                text: "Back to edit",
+              )
+            end
+          end
+
+          it "includes a preview element to be replaced by the Govspeak which JS will render into HTML" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
+                text: "Generating preview, please wait.",
+              )
+            end
+          end
+        end
+      end
+
+      context "when the field is NOT declared 'govspeak-enabled in the config" do
+        let(:component) do
+          described_class.new(
+            edition: edition,
+            field: plain_field,
+            schema: schema,
+            value: field_value,
+          )
+        end
+
+        it "does NOT display the 'Govspeak supported' hint" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            displays_no_indication_that_govspeak_is_supported(component)
+          end
+        end
+
+        it "does NOT  include a 'Preview' button" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_no_selector(
+              "button.js-app-c-govspeak-editor__preview-button",
+              text: "Preview",
+            )
+          end
+        end
+
+        it "does NOT include 'Back to edit' button" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_no_selector(
+              "button.js-app-c-govspeak-editor__back-button",
+              text: "Back to edit",
+            )
+          end
+        end
+
+        it "does NOT include a preview element to be replaced by the rendered Govspeak" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_no_selector(
+              ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
+              text: "Generating preview, please wait.",
+            )
+          end
+        end
+      end
+    end
+  end
+
   context "when textarea is built for a subschema" do
     let(:body) do
       {

--- a/test/components/edition/details/fields/textarea_component_test.rb
+++ b/test/components/edition/details/fields/textarea_component_test.rb
@@ -7,306 +7,308 @@ class Edition::Details::Fields::TextareaComponentTest < BaseComponentTestClass
 
   let(:edition) { build(:edition, :contact) }
 
-  let(:body) do
-    {
-      "type" => "object",
-      "patternProperties" => {
-        "*" => {
-          "type" => "object",
-          "properties" => {},
+  context "when textarea is built for a subschema" do
+    let(:body) do
+      {
+        "type" => "object",
+        "patternProperties" => {
+          "*" => {
+            "type" => "object",
+            "properties" => {},
+          },
         },
-      },
-    }
-  end
+      }
+    end
 
-  let(:subschema) do
-    Schema::EmbeddedSchema.new(
-      "telephones",
-      body,
-      "parent_schema_id",
-    )
-  end
-  let(:config) do
-    {
-      "schemas" => {
-        "parent_schema_id" => {
-          "subschemas" => {
-            "telephones" => {
-              "fields" => {
-                "video_relay_service" => {
-                  "fields" => {
-                    "prefix" => { "govspeak_enabled" => true },
+    let(:subschema) do
+      Schema::EmbeddedSchema.new(
+        "telephones",
+        body,
+        "parent_schema_id",
+      )
+    end
+    let(:config) do
+      {
+        "schemas" => {
+          "parent_schema_id" => {
+            "subschemas" => {
+              "telephones" => {
+                "fields" => {
+                  "video_relay_service" => {
+                    "fields" => {
+                      "prefix" => { "govspeak_enabled" => true },
+                    },
                   },
                 },
               },
             },
           },
         },
-      },
-    }
-  end
-
-  let(:schema) { stub(:schema, block_type: "schema") }
-
-  let(:field) do
-    Schema::Field::NestedField.new(
-      name: "prefix",
-      format: "string",
-      enum_values: nil,
-      default_value: "**Default** prefix: 18000 then",
-    )
-  end
-
-  let(:field_value) { nil }
-
-  let(:component) do
-    described_class.new(
-      edition: edition,
-      field: field,
-      schema:,
-      value: field_value,
-      nested_object_key: "video_relay_service",
-      subschema: subschema,
-    )
-  end
-
-  before do
-    helper_stub = stub(:helpers)
-    Edition::Details::Fields::TextareaComponent.any_instance.stubs(:helpers).returns(helper_stub)
-    helper_stub.stubs(:hint_text).returns(nil)
-    helper_stub.stubs(:humanized_label).returns("Translated label")
-
-    Schema::EmbeddedSchema
-      .stubs(:schema_settings)
-      .returns(config)
-  end
-
-  describe "GovspeakEnabledTextareaComponent" do
-    it "gives the textarea an ID describing path to field" do
-      render_inline component
-
-      assert_selector(COMPONENT_CLASS) do |component|
-        gives_textarea_id_describing_path_to_field(component)
-      end
+      }
     end
 
-    it "includes a translated _label_" do
-      render_inline component
+    let(:schema) { stub(:schema, block_type: "schema") }
 
-      assert_selector(COMPONENT_CLASS) do |component|
-        displays_label_using_translation_system(component)
-      end
+    let(:field) do
+      Schema::Field::NestedField.new(
+        name: "prefix",
+        format: "string",
+        enum_values: nil,
+        default_value: "**Default** prefix: 18000 then",
+      )
     end
 
-    it "includes a _name_ attribute representing nested field location" do
-      render_inline component
+    let(:field_value) { nil }
 
-      assert_selector(COMPONENT_CLASS) do |component|
-        sets_name_attribute_on_textarea_describing_nested_path_to_field(component)
-      end
+    let(:component) do
+      described_class.new(
+        edition: edition,
+        field: field,
+        schema:,
+        value: field_value,
+        nested_object_key: "video_relay_service",
+        subschema: subschema,
+      )
     end
 
-    describe "default value" do
-      context "when there is NO value set for the textarea" do
-        let(:field_value) { nil }
+    before do
+      helper_stub = stub(:helpers)
+      Edition::Details::Fields::TextareaComponent.any_instance.stubs(:helpers).returns(helper_stub)
+      helper_stub.stubs(:hint_text).returns(nil)
+      helper_stub.stubs(:humanized_label).returns("Translated label")
 
-        it "supplies the default value defined in the schema" do
-          render_inline component
+      Schema::EmbeddedSchema
+        .stubs(:schema_settings)
+        .returns(config)
+    end
 
-          assert_selector(COMPONENT_CLASS) do |component|
-            shows_default_value_in_textarea(component)
-          end
+    describe "GovspeakEnabledTextareaComponent" do
+      it "gives the textarea an ID describing path to field" do
+        render_inline component
+
+        assert_selector(COMPONENT_CLASS) do |component|
+          gives_textarea_id_describing_path_to_field(component)
         end
       end
 
-      context "when there IS a value set for the textarea" do
-        let(:field_value) {  "Field value *set*" }
+      it "includes a translated _label_" do
+        render_inline component
 
-        it "displays that value" do
-          render_inline component
-
-          assert_selector(COMPONENT_CLASS) do |component|
-            shows_set_value_in_textarea(component, "Field value *set*")
-          end
+        assert_selector(COMPONENT_CLASS) do |component|
+          displays_label_using_translation_system(component)
         end
       end
 
-      context "when there is an error on the field" do
-        before do
-          edition.errors.add(
-            :details_telephones_video_relay_service_prefix,
-            "blank",
-          )
+      it "includes a _name_ attribute representing nested field location" do
+        render_inline component
 
-          I18n.expects(:t).with(
-            "activerecord.errors.models.edition" \
-              ".attributes.details_telephones_video_relay_service_prefix.format".to_sym,
-            has_entry(message: "blank"),
-          ).returns("Prefix must be present")
+        assert_selector(COMPONENT_CLASS) do |component|
+          sets_name_attribute_on_textarea_describing_nested_path_to_field(component)
         end
+      end
 
-        it "adds an error class to the form group to highlight the area needing attention" do
-          render_inline component
+      describe "default value" do
+        context "when there is NO value set for the textarea" do
+          let(:field_value) { nil }
 
-          assert_selector(COMPONENT_CLASS) do |component|
-            component.assert_selector(".govuk-form-group.govuk-form-group--error")
+          it "supplies the default value defined in the schema" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              shows_default_value_in_textarea(component)
+            end
           end
         end
 
-        it "adds an error message to clarify the error and remedial action required" do
-          render_inline component
+        context "when there IS a value set for the textarea" do
+          let(:field_value) {  "Field value *set*" }
 
-          assert_selector(COMPONENT_CLASS) do |component|
-            component.assert_selector(
-              ".govuk-error-message",
-              text: "Prefix must be present",
+          it "displays that value" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              shows_set_value_in_textarea(component, "Field value *set*")
+            end
+          end
+        end
+
+        context "when there is an error on the field" do
+          before do
+            edition.errors.add(
+              :details_telephones_video_relay_service_prefix,
+              "blank",
             )
+
+            I18n.expects(:t).with(
+              "activerecord.errors.models.edition" \
+                ".attributes.details_telephones_video_relay_service_prefix.format".to_sym,
+              has_entry(message: "blank"),
+            ).returns("Prefix must be present")
+          end
+
+          it "adds an error class to the form group to highlight the area needing attention" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(".govuk-form-group.govuk-form-group--error")
+            end
+          end
+
+          it "adds an error message to clarify the error and remedial action required" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                ".govuk-error-message",
+                text: "Prefix must be present",
+              )
+            end
           end
         end
       end
-    end
 
-    describe "'Govspeak supported' indicator" do
-      context "when the field IS declared 'govspeak-enabled' in the config" do
-        let(:config) do
-          {
-            "schemas" => {
-              "parent_schema_id" => {
-                "subschemas" => {
-                  "telephones" => {
-                    "fields" => {
-                      "video_relay_service" => {
-                        "fields" => {
-                          "prefix" => { "govspeak_enabled" => true },
+      describe "'Govspeak supported' indicator" do
+        context "when the field IS declared 'govspeak-enabled' in the config" do
+          let(:config) do
+            {
+              "schemas" => {
+                "parent_schema_id" => {
+                  "subschemas" => {
+                    "telephones" => {
+                      "fields" => {
+                        "video_relay_service" => {
+                          "fields" => {
+                            "prefix" => { "govspeak_enabled" => true },
+                          },
                         },
                       },
                     },
                   },
                 },
               },
-            },
-          }
-        end
-
-        it "displays guidance to indicate 'Govspeak supported'" do
-          render_inline component
-
-          assert_selector(COMPONENT_CLASS) do |component|
-            displays_indication_that_govspeak_is_supported(component)
-          end
-        end
-
-        describe "hint ID mapping to textarea 'aria-describedby'" do
-          let(:expected_hint_id_to_aria_mapping) do
-            "edition_details_" \
-              "telephones_video_relay_service_prefix-" \
-              "hint"
+            }
           end
 
-          it "includes an 'aria-describedby' attribute on the textarea, to match the label hint's ID" do
+          it "displays guidance to indicate 'Govspeak supported'" do
             render_inline component
 
             assert_selector(COMPONENT_CLASS) do |component|
-              component.assert_selector(
-                "textarea[aria-describedby='#{expected_hint_id_to_aria_mapping}']",
-              )
+              displays_indication_that_govspeak_is_supported(component)
             end
           end
 
-          it "includes a 'Preview' button" do
+          describe "hint ID mapping to textarea 'aria-describedby'" do
+            let(:expected_hint_id_to_aria_mapping) do
+              "edition_details_" \
+                "telephones_video_relay_service_prefix-" \
+                "hint"
+            end
+
+            it "includes an 'aria-describedby' attribute on the textarea, to match the label hint's ID" do
+              render_inline component
+
+              assert_selector(COMPONENT_CLASS) do |component|
+                component.assert_selector(
+                  "textarea[aria-describedby='#{expected_hint_id_to_aria_mapping}']",
+                )
+              end
+            end
+
+            it "includes a 'Preview' button" do
+              render_inline component
+
+              assert_selector(COMPONENT_CLASS) do |component|
+                component.assert_selector(
+                  "button.js-app-c-govspeak-editor__preview-button",
+                  text: "Preview",
+                )
+              end
+            end
+
+            it "includes a 'Back to edit' button" do
+              render_inline component
+
+              assert_selector(COMPONENT_CLASS) do |component|
+                component.assert_selector(
+                  "button.js-app-c-govspeak-editor__back-button",
+                  text: "Back to edit",
+                )
+              end
+            end
+
+            it "includes a preview element to be replaced by the Govspeak which JS will render into HTML" do
+              render_inline component
+
+              assert_selector(COMPONENT_CLASS) do |component|
+                component.assert_selector(
+                  ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
+                  text: "Generating preview, please wait.",
+                )
+              end
+            end
+          end
+        end
+
+        context "when the field is NOT declared 'govspeak-enabled in the config" do
+          let(:config) do
+            {
+              "schemas" => {
+                "parent_schema_id" => {
+                  "subschemas" => {
+                    "telephones" => {
+                      "fields" => {
+                        "video_relay_service" => {
+                          "fields" => {
+                            "prefix" => {},
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            }
+          end
+
+          it "does NOT display the 'Govspeak supported' hint" do
             render_inline component
 
             assert_selector(COMPONENT_CLASS) do |component|
-              component.assert_selector(
+              displays_no_indication_that_govspeak_is_supported(component)
+            end
+          end
+
+          it "does NOT  include a 'Preview' button" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_no_selector(
                 "button.js-app-c-govspeak-editor__preview-button",
                 text: "Preview",
               )
             end
           end
 
-          it "includes a 'Back to edit' button" do
+          it "does NOT include 'Back to edit' button" do
             render_inline component
 
             assert_selector(COMPONENT_CLASS) do |component|
-              component.assert_selector(
+              component.assert_no_selector(
                 "button.js-app-c-govspeak-editor__back-button",
                 text: "Back to edit",
               )
             end
           end
 
-          it "includes a preview element to be replaced by the Govspeak which JS will render into HTML" do
+          it "does NOT include a preview element to be replaced by the rendered Govspeak" do
             render_inline component
 
             assert_selector(COMPONENT_CLASS) do |component|
-              component.assert_selector(
+              component.assert_no_selector(
                 ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
                 text: "Generating preview, please wait.",
               )
             end
-          end
-        end
-      end
-
-      context "when the field is NOT declared 'govspeak-enabled in the config" do
-        let(:config) do
-          {
-            "schemas" => {
-              "parent_schema_id" => {
-                "subschemas" => {
-                  "telephones" => {
-                    "fields" => {
-                      "video_relay_service" => {
-                        "fields" => {
-                          "prefix" => {},
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          }
-        end
-
-        it "does NOT display the 'Govspeak supported' hint" do
-          render_inline component
-
-          assert_selector(COMPONENT_CLASS) do |component|
-            displays_no_indication_that_govspeak_is_supported(component)
-          end
-        end
-
-        it "does NOT  include a 'Preview' button" do
-          render_inline component
-
-          assert_selector(COMPONENT_CLASS) do |component|
-            component.assert_no_selector(
-              "button.js-app-c-govspeak-editor__preview-button",
-              text: "Preview",
-            )
-          end
-        end
-
-        it "does NOT include 'Back to edit' button" do
-          render_inline component
-
-          assert_selector(COMPONENT_CLASS) do |component|
-            component.assert_no_selector(
-              "button.js-app-c-govspeak-editor__back-button",
-              text: "Back to edit",
-            )
-          end
-        end
-
-        it "does NOT include a preview element to be replaced by the rendered Govspeak" do
-          render_inline component
-
-          assert_selector(COMPONENT_CLASS) do |component|
-            component.assert_no_selector(
-              ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
-              text: "Generating preview, please wait.",
-            )
           end
         end
       end

--- a/test/unit/app/models/schema_test.rb
+++ b/test/unit/app/models/schema_test.rb
@@ -62,6 +62,46 @@ class SchemaTest < ActiveSupport::TestCase
     end
   end
 
+  describe "#govspeak_enabled?(field_name:)" do
+    let(:schema_id) { "content_block_contact" }
+
+    let(:body) do
+      {
+        "type" => "object",
+        "properties" => {},
+      }
+    end
+
+    let(:schema) { Schema.new(schema_id, body) }
+
+    let(:config) do
+      {
+        "schemas" => {
+          schema_id => {
+            "fields" => {
+              "field_1" => {},
+              "field_2" => { "govspeak_enabled" => true },
+            },
+          },
+        },
+      }
+    end
+
+    before do
+      Schema
+        .stubs(:schema_settings)
+        .returns(config)
+    end
+
+    it "returns true if the given field is govspeak_enabled" do
+      assert(schema.govspeak_enabled?(field_name: "field_2"))
+    end
+
+    it "returns false if the given field is NOT govspeak_enabled" do
+      assert_not(schema.govspeak_enabled?(field_name: "field_1"))
+    end
+  end
+
   describe "#required_fields" do
     describe "when there are no required fields" do
       it "returns an empty array" do


### PR DESCRIPTION
See Jira [CM-483](https://gov-uk.atlassian.net/browse/CM-483)

Previously only subschema (`EmbeddedSchema`) properties had
the ability to be identified as `govspeak-enabled?`. However
this behaviour is also needed on properties of the `Schema`.

<img width="1469" height="1403" alt="govspeak_enabled_schema_property" src="https://github.com/user-attachments/assets/6a48933b-6d95-4113-bdb7-7dbe406f4585" />


[CM-483]: https://gov-uk.atlassian.net/browse/CM-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ