### PR TITLE
CM-486 : Enable Turbo only where we want it (Validation of video relay service broken)

### DIFF
--- a/app/views/editions/preview.turbo_stream.erb
+++ b/app/views/editions/preview.turbo_stream.erb
@@ -12,5 +12,8 @@
     secondary_quiet: true,
     href: request.referer,
     margin_bottom: false,
+    data_attributes: {
+      turbo: true,
+    },
   }) %>
 <% end %>

--- a/app/views/editions/workflow/group_objects.html.erb
+++ b/app/views/editions/workflow/group_objects.html.erb
@@ -16,6 +16,7 @@
       margin_bottom: false,
       data_attributes: {
         turbo_stream: true,
+        turbo: true,
       },
     }) %>
   </div>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -46,7 +46,7 @@
     <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>
 
-    <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank? %>" id="main-content" data-module="ga4-link-tracker" role="main" data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'>
+    <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank? %>" id="main-content" data-module="ga4-link-tracker" role="main" data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }' data-turbo="false">
 
       <%= render Shared::FlashNoticeComponent.new(message: flash[:notice], html_safe: flash["html_safe"]) if flash[:notice] %>
       <%= render Shared::FlashAlertComponent.new(message: flash[:alert], html_safe: flash["html_safe"]) if flash[:alert] && yield(:error_summary).blank? %>

--- a/app/views/shared/embedded_objects/select_subschema.html.erb
+++ b/app/views/shared/embedded_objects/select_subschema.html.erb
@@ -16,6 +16,7 @@
       margin_bottom: false,
       data_attributes: {
         turbo_stream: true,
+        turbo: true,
       },
     }) %>
   </div>

--- a/test/integration/layout_test.rb
+++ b/test/integration/layout_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "capybara/rails"
+
+class Admin::LayoutTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+  extend Minitest::Spec::DSL
+
+  setup do
+    login_as_admin
+
+    Organisation.stubs(:all).returns([organisation])
+  end
+
+  let(:organisation) { build(:organisation) }
+
+  it "disable Turbo drive by default" do
+    visit "/"
+
+    main_wrapper = find(".govuk-main-wrapper")
+    assert_equal("false", main_wrapper["data-turbo"])
+  end
+end


### PR DESCRIPTION
See [CM-486: Validation of telephone video relay service broken](https://gov-uk.atlassian.net/browse/CM-486)

We've introduced the use of Rails' "Turbo drive" mechanism for loading fragments of HTML for enhanced performance and interactivity without introducing the overhead of custom JS for Ajax requests. However, we don't want Turbo to highjack all form POSTs as this plays havoc with our existing behaviour, especially the handling of errors.

To disable Turbo by default it's recommended to set `data-turbo="false"` [on the body tag][] but as we're using the [admin layout component][] we don't have ready access to the `body` tag.

Instead we set it on the `.govuk-main-wrapper` element.

And we enable Turbo in the specific places where we need it:

- the "Preview" button on the "group objects" and "select subschema" pages

- the "preview.turbo-stream" template which renders the "Close preview button"

[on the body tag]:
https://github.com/hotwired/turbo/issues/918#issuecomment-1545241471

[admin layout component]:
https://components.publishing.service.gov.uk/component-guide/layout_for_admin