### PR TITLE
CM-374: Describe Govspeak-enabled fields in Contact

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $govuk-page-width: 1140px;
 @import "components/host-editions-table-component";
 @import "components/opening-hours-component";
 @import "components/opening-hours-item-component";
+@import "components/textarea-component";
 @import "components/timeline-component";
 
 @import "objects/grid";

--- a/app/assets/stylesheets/components/_textarea-component.scss
+++ b/app/assets/stylesheets/components/_textarea-component.scss
@@ -1,0 +1,9 @@
+.app-c-content-block-manager-textarea-component {
+  .app-c-govspeak-editor.govuk-form-group {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  .guidance.govspeak-supported.govuk-hint {
+    margin-bottom: govuk-spacing(5);
+  }
+}

--- a/app/components/edition/details/fields/textarea_component.html.erb
+++ b/app/components/edition/details/fields/textarea_component.html.erb
@@ -9,7 +9,7 @@
                 hint_id: aria_described_by,
                 rows: 5,
     } %>
-    <p class="govuk-body guidance govspeak-supported govuk-hint govuk-!-margin-top-2 govuk-!-margin-bottom-5">
+    <p class="govuk-body guidance govspeak-supported govuk-hint">
       Govspeak supported
     </p>
   <% else %>

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -170,6 +170,40 @@ Feature: Create a contact object
       }
     }
     """
+    And the schema has a subschema "addresses":
+    """
+    {
+      "type":"object",
+      "properties": {
+        "country": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "postal_code": {
+          "type": "string"
+        },
+        "recipient": {
+          "type": "string"
+        },
+        "state_or_county": {
+          "type": "string"
+        },
+        "street_address": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "default": "Address"
+        },
+        "town_or_city": {
+          "type": "string"
+        }
+      }
+    }
+    """
+
     And the schema "contact" has a group "contact_methods" with the following subschemas:
       | email_addresses | telephones | contact_links |
     And I visit the Content Block Manager home page
@@ -259,3 +293,10 @@ Feature: Create a contact object
     And I confirm my answers are correct
     And I review and confirm my answers are correct
     And I should be taken to the confirmation page for a new "contact"
+
+  Scenario: Block editor sees expected Govspeak-enabled fields
+    When I am creating a contact content block
+    Then I see that the block description is Govspeak-enabled
+    When I am creating a contact address
+    Then I see that the contact address description is Govspeak-enabled
+

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -75,6 +75,9 @@ Feature: Create a contact object
         "title": {
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "video_relay_service": {
           "type": "object",
           "properties": {
@@ -306,6 +309,9 @@ Feature: Create a contact object
     Then I see that the contact link description is Govspeak-enabled
     When I am creating an email address
     Then I see that the contact email address description is Govspeak-enabled
+    When I am creating a telephone
+    Then I see that the contact telephone description is Govspeak-enabled
+
 
 
 

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -313,6 +313,8 @@ Feature: Create a contact object
     Then I see that the contact telephone description is Govspeak-enabled
     And I see that the telephone video relay service prefix is Govspeak-enabled
     And I see that the telephone bsl guidance value is Govspeak-enabled
+    And I see that the telephone opening hours field is Govspeak-enabled
+
 
 
 

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -299,4 +299,7 @@ Feature: Create a contact object
     Then I see that the block description is Govspeak-enabled
     When I am creating a contact address
     Then I see that the contact address description is Govspeak-enabled
+    When I am creating a contact link
+    Then I see that the contact link description is Govspeak-enabled
+
 

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -312,6 +312,7 @@ Feature: Create a contact object
     When I am creating a telephone
     Then I see that the contact telephone description is Govspeak-enabled
     And I see that the telephone video relay service prefix is Govspeak-enabled
+    And I see that the telephone bsl guidance value is Govspeak-enabled
 
 
 

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -38,6 +38,9 @@ Feature: Create a contact object
         },
         "body": {
           "type": "string"
+        },
+        "description": {
+          "type": "string"
         }
       }
     }
@@ -301,5 +304,8 @@ Feature: Create a contact object
     Then I see that the contact address description is Govspeak-enabled
     When I am creating a contact link
     Then I see that the contact link description is Govspeak-enabled
+    When I am creating an email address
+    Then I see that the contact email address description is Govspeak-enabled
+
 
 

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -311,6 +311,7 @@ Feature: Create a contact object
     Then I see that the contact email address description is Govspeak-enabled
     When I am creating a telephone
     Then I see that the contact telephone description is Govspeak-enabled
+    And I see that the telephone video relay service prefix is Govspeak-enabled
 
 
 

--- a/features/step_definitions/contact_steps.rb
+++ b/features/step_definitions/contact_steps.rb
@@ -16,6 +16,13 @@ When("I am creating a contact link") do
   click_button "Save and continue"
 end
 
+When("I am creating an email address") do
+  visit_new_contact_block_page
+  create_contact_block
+  choose "Email address"
+  click_button "Save and continue"
+end
+
 def visit_new_contact_block_page
   visit root_path
   click_link "Create content block"

--- a/features/step_definitions/contact_steps.rb
+++ b/features/step_definitions/contact_steps.rb
@@ -23,6 +23,13 @@ When("I am creating an email address") do
   click_button "Save and continue"
 end
 
+When("I am creating a telephone") do
+  visit_new_contact_block_page
+  create_contact_block
+  choose "Telephone"
+  click_button "Save and continue"
+end
+
 def visit_new_contact_block_page
   visit root_path
   click_link "Create content block"

--- a/features/step_definitions/contact_steps.rb
+++ b/features/step_definitions/contact_steps.rb
@@ -1,0 +1,27 @@
+When("I am creating a contact content block") do
+  visit_new_contact_block_page
+end
+
+When("I am creating a contact address") do
+  visit_new_contact_block_page
+  create_contact_block
+  choose "Address"
+  click_button "Save and continue"
+end
+
+def visit_new_contact_block_page
+  visit root_path
+  click_link "Create content block"
+
+  @schema = @schemas["contact"]
+  Schema.expects(:find_by_block_type).with("contact").at_least_once.returns(@schema)
+  choose "Contact"
+  click_button "Save and continue"
+end
+
+def create_contact_block
+  fill_in("Contact name", with: "Contact block title")
+  fill_in("Description", with: "Description of block")
+  select("Ministry of Example")
+  click_button "Save and continue"
+end

--- a/features/step_definitions/contact_steps.rb
+++ b/features/step_definitions/contact_steps.rb
@@ -9,6 +9,13 @@ When("I am creating a contact address") do
   click_button "Save and continue"
 end
 
+When("I am creating a contact link") do
+  visit_new_contact_block_page
+  create_contact_block
+  choose "Contact link"
+  click_button "Save and continue"
+end
+
 def visit_new_contact_block_page
   visit root_path
   click_link "Create content block"

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -6,6 +6,10 @@ Then("I see that the pension rate description is Govspeak-enabled") do
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_rates_description")
 end
 
+Then("I see that the contact address description is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_addresses_description")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -22,6 +22,10 @@ Then("I see that the contact telephone description is Govspeak-enabled") do
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_description")
 end
 
+Then("I see that the telephone video relay service prefix is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_video_relay_service_prefix")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -1,37 +1,31 @@
-Then("I see that the block description is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_description")
-end
+Then(/^I see that the ([^"]*) is Govspeak-enabled$/) do |field|
+  id = case field
+       when "block description"
+         "edition_details_description"
 
-Then("I see that the pension rate description is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_rates_description")
-end
+       when "pension rate description"
+         "edition_details_rates_description"
 
-Then("I see that the contact address description is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_addresses_description")
-end
+       when "contact address description"
+         "edition_details_addresses_description"
+       when "contact link description"
+         "edition_details_contact_links_description"
+       when "contact email address description"
+         "edition_details_email_addresses_description"
+       when "contact telephone description"
+         "edition_details_telephones_description"
+       when "telephone video relay service prefix"
+         "edition_details_telephones_video_relay_service_prefix"
+       when "telephone bsl guidance value"
+         "edition_details_telephones_bsl_guidance_value"
+       when "telephone opening hours field"
+         "edition_details_telephones_opening_hours_opening_hours"
 
-Then("I see that the contact link description is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_contact_links_description")
-end
+       else
+         raise "Unexpected field name: #{field}"
+       end
 
-Then("I see that the contact email address description is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_email_addresses_description")
-end
-
-Then("I see that the contact telephone description is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_description")
-end
-
-Then("I see that the telephone video relay service prefix is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_video_relay_service_prefix")
-end
-
-Then("I see that the telephone bsl guidance value is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_bsl_guidance_value")
-end
-
-Then("I see that the telephone opening hours field is Govspeak-enabled") do
-  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_opening_hours_opening_hours")
+  expect_to_see_a_govspeak_enabled_textarea_for_id(id)
 end
 
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -18,6 +18,10 @@ Then("I see that the contact email address description is Govspeak-enabled") do
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_email_addresses_description")
 end
 
+Then("I see that the contact telephone description is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_description")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -26,6 +26,10 @@ Then("I see that the telephone video relay service prefix is Govspeak-enabled") 
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_video_relay_service_prefix")
 end
 
+Then("I see that the telephone bsl guidance value is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_bsl_guidance_value")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -30,6 +30,10 @@ Then("I see that the telephone bsl guidance value is Govspeak-enabled") do
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_bsl_guidance_value")
 end
 
+Then("I see that the telephone opening hours field is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_telephones_opening_hours_opening_hours")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -10,6 +10,10 @@ Then("I see that the contact address description is Govspeak-enabled") do
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_addresses_description")
 end
 
+Then("I see that the contact link description is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_contact_links_description")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/step_definitions/govspeak_steps.rb
+++ b/features/step_definitions/govspeak_steps.rb
@@ -14,6 +14,10 @@ Then("I see that the contact link description is Govspeak-enabled") do
   expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_contact_links_description")
 end
 
+Then("I see that the contact email address description is Govspeak-enabled") do
+  expect_to_see_a_govspeak_enabled_textarea_for_id("edition_details_email_addresses_description")
+end
+
 def expect_to_see_a_govspeak_enabled_textarea_for_id(id)
   assert(
     page.has_selector?(".app-c-govspeak-editor ##{id}"),

--- a/features/support/publishing_api.rb
+++ b/features/support/publishing_api.rb
@@ -19,6 +19,8 @@ Before do
     .to_return(body: { links: {} }.to_json)
   stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/expanded-links})
     .to_return(body: { expanded_links: {} }.to_json)
+  stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/content\?document_type=world_location})
+    .to_return(body: { results: [{ title: "United Kingdom" }] }.to_json)
 end
 
 World(GdsApi::TestHelpers::PublishingApi)


### PR DESCRIPTION
This cucumber feature verifies that the expected fields within the "Contact" 
content block are indeed Govspeak-enabled.

We need to ensure that our stubbed schema includes the
properties which are (in `/config/content_block_manager.yml`)
configured as `govspeak_enabled: true` -- and then we can assert
that the expected textareas are indeed wrapped in the
"govspeak editor".

This should prevent inadvertent regressions, e.g. when the the config is edited.

We also tweak the spacing around the "Govspeak supported" guidance:

<img width="780" height="392" alt="style-margins_govspeak_textarea" src="https://github.com/user-attachments/assets/7cdf2e9a-eac4-4ecb-85aa-323300fef279" />
