### PR TITLE
(CM-502) Group subschemas by their group order

### DIFF
--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -62,7 +62,7 @@ class Schema
   end
 
   def subschemas_for_group(group)
-    subschemas.select { |s| s.group == group }
+    subschemas.select { |s| s.group == group }.sort_by(&:group_order)
   end
 
   def permitted_params

--- a/test/unit/app/models/schema_test.rb
+++ b/test/unit/app/models/schema_test.rb
@@ -411,8 +411,8 @@ class SchemaTest < ActiveSupport::TestCase
   describe "#subschemas_for_group" do
     let(:group_1_subschemas) do
       [
-        stub(:subschema, group: "group_1"),
-        stub(:subschema, group: "group_1"),
+        stub(:subschema, group: "group_1", group_order: 2),
+        stub(:subschema, group: "group_1", group_order: 1),
       ]
     end
 
@@ -428,8 +428,8 @@ class SchemaTest < ActiveSupport::TestCase
       schema.stubs(:subschemas).returns(subschemas)
     end
 
-    it "returns subschemas for a group" do
-      assert_equal schema.subschemas_for_group("group_1"), group_1_subschemas
+    it "returns subschemas for a group sorted by the group order" do
+      assert_equal schema.subschemas_for_group("group_1"), [group_1_subschemas[1], group_1_subschemas[0]]
     end
 
     it "returns an empty array when no subschemas can be found" do


### PR DESCRIPTION
This keeps the order consistent with how subschemas are shown in their tabs