### PR TITLE
Generate release notes when creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,5 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
     secrets:
       GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+    with:
+      generate_release_notes: true


### PR DESCRIPTION
We’ve added an optional input to the release workflow to allow us to automatically generate release notes (https://github.com/alphagov/govuk-infrastructure/pull/2797)

This sets the input to `true`, so we automatically generate release notes when releasing code.

As we practice continuous delivery, it’ll usually be one PR per release, but this is still useful to link PRs to releases.