### PR TITLE
(CM-343) Order subschemas by `group_order` for `default_order`

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -66,7 +66,7 @@ class Edition < ApplicationRecord
   end
 
   def default_order
-    document.schema.subschemas.map { |subschema|
+    document.schema.subschemas.sort_by(&:group_order).map { |subschema|
       item_keys = details[subschema.block_type]&.keys || []
       item_keys.map do |item_key|
         "#{subschema.block_type}.#{item_key}"

--- a/features/create_contact_object.feature
+++ b/features/create_contact_object.feature
@@ -262,17 +262,17 @@ Feature: Create a contact object
       | Recipient  | 123 Fake Street | Springfield  | ABC 123     |
     And I click on Preview
     And I click on reorder
-    And I click to move the contact form to the top
-    Then I should see the contact form moved to the top
+    And I change the order of the contact methods
+    Then I should see the contact methods in the new order
     When I click to save the order
     Then I should see a preview of my contact
-    And the contact form should be at the top
+    And the contact methods should be in the new order
     When I click to close the preview
     And I save and continue
     And I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a new "contact"
     When I click to view the content block
-    Then the contact form should be at the top
+    Then the contact methods should be in the new order
 
   @javascript
   Scenario: GDS editor creates a Contact with an email address and a telephone

--- a/features/step_definitions/reorder_steps.rb
+++ b/features/step_definitions/reorder_steps.rb
@@ -2,23 +2,23 @@ And(/^I click on reorder$/) do
   click_on "Reorder"
 end
 
-And(/^I click to move the contact form to the top$/) do
-  find("a[data-testid='contact_links.contact-form-move-up-button']").click
+And(/^I change the order of the contact methods$/) do
+  find("a[data-testid='email_addresses.email-us-move-up-button']").click
 end
 
 And(/^I click to save the order/) do
   click_on "Save order"
 end
 
-And(/^the contact form should be at the top$/) do
+And(/^the contact methods should be in the new order$/) do
   items = page.find_all(".content-block__contact-list--nested")
 
-  assert_equal "Contact Form", items[0].find_all(".content-block__contact-key")[0].text
+  assert_equal "Email us", items[0].find_all(".content-block__contact-key")[0].text
 end
 
-Then(/^I should see the contact form moved to the top$/) do
+Then(/^I should see the contact methods in the new order$/) do
   Capybara.current_session.driver.with_playwright_page do |page|
     item = page.get_by_testid("reorder-item-0")
-    expect(item).to playwright_matchers.have_text("Contact Form")
+    expect(item).to playwright_matchers.have_text("Email us")
   end
 end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -454,9 +454,9 @@ class EditionTest < ActiveSupport::TestCase
     let(:subschemas) do
       [
         stub(:subschema, id: "email_addresses", block_type: "email_addresses", group_order: 1),
-        stub(:subschema, id: "telephones", block_type: "telephones", group_order: 2),
-        stub(:subschema, id: "addresses", block_type: "addresses", group_order: 3),
-        stub(:subschema, id: "contact_links", block_type: "contact_links", group_order: 4),
+        stub(:subschema, id: "telephones", block_type: "telephones", group_order: 4),
+        stub(:subschema, id: "addresses", block_type: "addresses", group_order: 2),
+        stub(:subschema, id: "contact_links", block_type: "contact_links", group_order: 3),
       ]
     end
     let(:schema) { stub(:schema, subschemas: subschemas, body: {}) }
@@ -470,9 +470,9 @@ class EditionTest < ActiveSupport::TestCase
       assert_equal edition.default_order, %w[
         email_addresses.email_address_1
         email_addresses.email_address_2
-        telephones.telephone_1
         addresses.address_1
         contact_links.contact_link_1
+        telephones.telephone_1
       ]
     end
   end


### PR DESCRIPTION
When fetching the default order, subschemas should be ordered by the order defined in the config (via [`group_order`](https://github.com/alphagov/content-block-manager/blob/main/docs/configuration.md#schemasschema_namesubschemassubschema_namegroup_order) if present). At the moment, the default order is different to the order presented in the preview, which is confusing to users.

We had the tests set up with this in mind, but they were passing by accident, because the order we expected was linear. I’ve fixed the tests, so the `group_order` defined in the test setups is no longer linear, so we can confirm that subschemas are being ordered correctly.

## Screenshots

### Before

<img width="1904" height="2164" alt="image" src="https://github.com/user-attachments/assets/0a497f62-85e9-416f-b5d0-089e2ac1e376" />

(Ordered with Address, Contact Link, Email, Telephone)

### After

<img width="1904" height="2164" alt="image" src="https://github.com/user-attachments/assets/4ab8ba9e-1432-476c-8fe1-b760aa536d45" />

(Ordered with Address, Email, Telephone, Contact Link)