### PR TITLE
(CM-343) Ensure buttons are rendered correctly when reordering

### DIFF
--- a/app/components/edition/reorder_component.html.erb
+++ b/app/components/edition/reorder_component.html.erb
@@ -26,7 +26,7 @@
               } %>
             <% end %>
 
-            <% unless position == @order.length - 1 %>
+            <% unless position == item_keys.length - 1 %>
               <%= render "govuk_publishing_components/components/button", {
                 text: "Down",
                 href: move_path(position, item, :down),

--- a/app/components/edition/reorder_component.rb
+++ b/app/components/edition/reorder_component.rb
@@ -7,15 +7,17 @@ class Edition::ReorderComponent < ViewComponent::Base
 
 private
 
-  attr_reader :edition, :order, :redirect_path
+  attr_reader :edition, :redirect_path
 
   def item_keys
-    items_missing_from_order = edition.default_order - order
-    order + items_missing_from_order
+    @item_keys ||= begin
+      items_missing_from_order = edition.default_order - @order
+      @order + items_missing_from_order
+    end
   end
 
   def move_path(position, item, direction)
-    updated_order = order.dup
+    updated_order = item_keys.dup
     new_position = direction == :up ? position - 1 : position + 1
     updated_order.insert(
       new_position,

--- a/test/components/edition/reorder_component_test.rb
+++ b/test/components/edition/reorder_component_test.rb
@@ -109,6 +109,103 @@ class Edition::ReorderComponentTest < ViewComponent::TestCase
       items[4].assert_selector ".govspeak", text: "email_addresses.email_address_4"
       items[5].assert_selector ".govspeak", text: "telephones.telephone_2"
     end
+
+    it "renders up and down buttons with the correct paths" do
+      render_inline component
+
+      wrapper = page.find(".app-c-content-block-manager-reorder-component")
+      items = wrapper.all(".app-c-content-block-manager-reorder-component__item")
+
+      assert_equal 6, items.count
+
+      items[0].assert_no_selector "a", text: "Up"
+      assert_button_exists(wrapper: items[0], label: "Down", order: %w[
+        email_addresses.email_address_2
+        email_addresses.email_address_1
+        telephones.telephone_1
+        email_addresses.email_address_3
+        email_addresses.email_address_4
+        telephones.telephone_2
+      ])
+
+      assert_button_exists(wrapper: items[1], label: "Up", order: %w[
+        email_addresses.email_address_2
+        email_addresses.email_address_1
+        telephones.telephone_1
+        email_addresses.email_address_3
+        email_addresses.email_address_4
+        telephones.telephone_2
+      ])
+      assert_button_exists(wrapper: items[1], label: "Down", order: %w[
+        email_addresses.email_address_1
+        telephones.telephone_1
+        email_addresses.email_address_2
+        email_addresses.email_address_3
+        email_addresses.email_address_4
+        telephones.telephone_2
+      ])
+
+      assert_button_exists(wrapper: items[2], label: "Up", order: %w[
+        email_addresses.email_address_1
+        telephones.telephone_1
+        email_addresses.email_address_2
+        email_addresses.email_address_3
+        email_addresses.email_address_4
+        telephones.telephone_2
+      ])
+      assert_button_exists(wrapper: items[2], label: "Down", order: %w[
+        email_addresses.email_address_1
+        email_addresses.email_address_2
+        email_addresses.email_address_3
+        telephones.telephone_1
+        email_addresses.email_address_4
+        telephones.telephone_2
+      ])
+
+      assert_button_exists(wrapper: items[3], label: "Up", order: %w[
+        email_addresses.email_address_1
+        email_addresses.email_address_2
+        email_addresses.email_address_3
+        telephones.telephone_1
+        email_addresses.email_address_4
+        telephones.telephone_2
+      ])
+      assert_button_exists(wrapper: items[3], label: "Down", order: %w[
+        email_addresses.email_address_1
+        email_addresses.email_address_2
+        telephones.telephone_1
+        email_addresses.email_address_4
+        email_addresses.email_address_3
+        telephones.telephone_2
+      ])
+
+      assert_button_exists(wrapper: items[4], label: "Up", order: %w[
+        email_addresses.email_address_1
+        email_addresses.email_address_2
+        telephones.telephone_1
+        email_addresses.email_address_4
+        email_addresses.email_address_3
+        telephones.telephone_2
+      ])
+      assert_button_exists(wrapper: items[4], label: "Down", order: %w[
+        email_addresses.email_address_1
+        email_addresses.email_address_2
+        telephones.telephone_1
+        email_addresses.email_address_3
+        telephones.telephone_2
+        email_addresses.email_address_4
+      ])
+
+      assert_button_exists(wrapper: items[5], label: "Up", order: %w[
+        email_addresses.email_address_1
+        email_addresses.email_address_2
+        telephones.telephone_1
+        email_addresses.email_address_3
+        telephones.telephone_2
+        email_addresses.email_address_4
+      ])
+      items[5].assert_no_selector "a", text: "Down"
+    end
   end
 
   def assert_button_exists(wrapper:, label:, order:)


### PR DESCRIPTION
When rendering the buttons, we were still using the original `@order` instance variable, which doesn’t include any newly added items, so the `up` and `down` buttons were rendering incorrectly. We were also using the initially set `order` when rendering the URLs for moving the items, so I’ve fixed that too, as well as adding tests to ensure the buttons are rendered correctly with the right paths.

## Screenshot

### Before

<img width="1904" height="2386" alt="image" src="https://github.com/user-attachments/assets/04625889-a7b5-416c-a7f3-82ba80a86796" />

### After

<img width="1904" height="2386" alt="image" src="https://github.com/user-attachments/assets/efc29803-417d-45bf-8fdc-1a17cec23f3d" />