### PR TITLE
(CM-518) Multi-line `street_address`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
-    content_block_tools (1.3.1)
+    content_block_tools (1.4.0)
       actionview (>= 6, < 8.0.3)
       govspeak (>= 10.6.3)
       rails (>= 6, < 8.0.3)
@@ -1026,7 +1026,7 @@ CHECKSUMS
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
   connection_pool (2.5.4) sha256=e9e1922327416091f3f6542f5f4446c2a20745276b9aa796dd0bb2fd0ea1e70a
-  content_block_tools (1.3.1) sha256=320a063da2e032b5f0b22b543eddfa75ff793e2c3f7c632912e91547b3c1c181
+  content_block_tools (1.4.0) sha256=f4eeba88e8202480fd17e0bcbe075f81409392bbae0b49d86da84b9931a90110
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cucumber (10.1.0) sha256=bd9f5783b6cc2f1113ed4e64822459d4e73c973063f2325d89b5d555e4fe3e05

--- a/config/content_block_manager.yml
+++ b/config/content_block_manager.yml
@@ -131,6 +131,9 @@ schemas:
           country:
             component:
               country
+          street_address:
+            component:
+              textarea
           description:
             component:
               textarea


### PR DESCRIPTION
Very simple change here to make it so that:

1. When rendering the `street_address` field in an address, it is able to render multi-line text properly (showing newlines as `< br />` tags.)
2. When inputting a `street_address`, provides a `textarea` component for multi-line input.

## After:

<img width="1187" height="735" alt="Screenshot 2025-10-07 at 13 27 48" src="https://github.com/user-attachments/assets/e4e0eda9-0cce-460e-bb51-5289b7d64661" />


## Before

<img width="1146" height="654" alt="Screenshot 2025-10-07 at 13 28 15" src="https://github.com/user-attachments/assets/f66d264f-cf83-4a56-9b65-6a02a440de61" />

## Note

Note that on the non-preview view of the address the street address field appears, like the description field, across a single line:


<img width="45%"  alt="Screenshot 2025-10-07 at 13 36 13" src="https://github.com/user-attachments/assets/50e756c6-3769-4892-bb95-175b9a72138b" />
<img width="45%"  alt="Screenshot 2025-10-07 at 13 34 36" src="https://github.com/user-attachments/assets/d4b6ac99-c0f7-49c7-980e-8c032688b5e3" />

(click to embiggen ^)
