### PR TITLE
(CM-535) Only show preview button for composed blocks

### DIFF
--- a/app/views/editions/workflow/review.html.erb
+++ b/app/views/editions/workflow/review.html.erb
@@ -7,8 +7,10 @@
   } %>
 <% end %>
 
-<% content_for :title_side do %>
-  <%= render "shared/preview_link", edition: @edition %>
+<% if @edition.schema.embeddable_as_block? %>
+  <% content_for :title_side do %>
+    <%= render "shared/preview_link", edition: @edition %>
+  <% end %>
 <% end %>
 
 <% if @error_summary_errors %>

--- a/features/create_pension_object.feature
+++ b/features/create_pension_object.feature
@@ -58,6 +58,7 @@ Feature: Create a content object
     When I save and continue
     Then I am asked to review my answers for a "pension"
     And I should see a button labelled "Create"
+    And I should not see a preview button
     And I review and confirm my answers are correct
     Then the edition should have been created successfully
     And I should be taken to the confirmation page for a new "pension"

--- a/features/edit_object.feature
+++ b/features/edit_object.feature
@@ -42,6 +42,7 @@ Feature: Edit a content object
     Then I should be on the "review" step
     And I should see a back link to the "schedule_publishing" step
     Then I should see a button labelled "Publish"
+    And I should not see a preview button
     When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block

--- a/features/step_definitions/preview_block_steps.rb
+++ b/features/step_definitions/preview_block_steps.rb
@@ -2,6 +2,10 @@ When(/^I click on Preview$/) do
   preview_block_button.click
 end
 
+Then("I should not see a preview button") do
+  expect(page).to_not have_selector("a[title='Preview block']", text: "Preview")
+end
+
 Then(/^I should see a preview of my contact$/) do
   within ".app-views-editions-preview" do
     assert_text @title


### PR DESCRIPTION
We initially added a preview button only in the grouped objects workflow step, which only shows for composed blocks. Since then, we also added the button at the review stage, which shows for all block types.

As non-composed blocks aren’t embeddable as a single block, then showing a preview of the block is irrelevant, so let’s hide the link to the preview.