### PR TITLE
CM-529: Tweak layout of textarea hint/preview button

### DIFF
--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -6,7 +6,7 @@
   text-align: right;
   display: flex;
   justify-content: end;
-  gap: govuk-spacing(2);
+  margin-top: govuk-spacing(-9);
 }
 
 .app-c-govspeak-editor__textarea--hidden {

--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -30,25 +30,25 @@
 
 <%= tag.div class: classes, data: data_attributes do %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half ">
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
       <%= render "govuk_publishing_components/components/label", {
         id: label_id,
         html_for: id,
         hint_id: hint_id,
         hint_text: hint,
       }.merge(label.symbolize_keys) %>
-    </div>
-    <div class="govuk-grid-column-one-half app-c-govspeak-editor__preview-button-wrapper">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Preview",
-        secondary_quiet: true,
-        margin_bottom: hint ? 5 : 2,
-        classes: "js-app-c-govspeak-editor__preview-button",
-        data_attributes: preview_button_data_attributes,
-        aria_controls: preview_id,
-        aria_describedby: label_id,
-        type: "button",
-      } %>
+
+      <div class="app-c-govspeak-editor__preview-button-wrapper">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Preview",
+          secondary_quiet: true,
+          margin_bottom: hint ? 5 : 2,
+          classes: "js-app-c-govspeak-editor__preview-button",
+          data_attributes: preview_button_data_attributes,
+          aria_controls: preview_id,
+          aria_describedby: label_id,
+          type: "button",
+        } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Back to edit",
         secondary_quiet: true,
@@ -59,6 +59,7 @@
         aria_describedby: label_id,
         type: "button",
       } %>
+      </div>
     </div>
   </div>
   <div class="app-c-govspeak-editor__textarea">


### PR DESCRIPTION
## Issue

Textarea hint is trapped in a 1/2 width layout column:

<img width="1100" height="555" alt="preview_hint_half_width" src="https://github.com/user-attachments/assets/be401def-e11b-489f-ab20-97e3ca9298bb" />


## Fix

We:

- move the preview button and the label/hint into the same full-width column and add some bottom margin to this element

- move the preview button upwards

NB: there might be a problem with really long hint text which wraps as this would collide with the preview button.

### Edit mode
<img width="1017" height="502" alt="textarea_preview_edit_mode" src="https://github.com/user-attachments/assets/f0ab0ed1-f5af-4bb3-b5a2-85dc7176158b" />

### Preview mode
<img width="1023" height="567" alt="textarea_preview_preview_mode" src="https://github.com/user-attachments/assets/6badb091-7c94-4e1c-b94f-897358d82890" />

