### PR TITLE
CM-530: Correct hint text on contact.address.description

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
           label: This will display as link text.
           description: For example, is there anything the user should know, prepare or include before using the contact link.
         addresses:
-          description: For example, is there anything the user should know, prepare or include before using any contact method.
+          description: For example, is there anything the user should know, prepare or include before using the address.
         email_addresses:
           email_address: Write email addresses in full, in lower case. Prioritise team email addresses over personal email addresses for users.
           subject: Set a default subject line that will automatically pre-fill when users send an email using the email link.


### PR DESCRIPTION
See Jira [CM-530](https://gov-uk.atlassian.net/browse/CM-530)

Now the "hint" guidance on the contact's address description field refers to the "address" rather than "any contact"

<img width="825" height="805" alt="contact-address-description-hint" src="https://github.com/user-attachments/assets/ebe5f5ee-0897-4f02-b19d-1de8fd3ad09d" />


[CM-530]: https://gov-uk.atlassian.net/browse/CM-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ