### PR TITLE
CM-531: Style video relay service prefix textarea to single line

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,8 @@ $govuk-page-width: 1140px;
 @import "components/reorder-component";
 @import "components/textarea-component";
 @import "components/timeline-component";
+@import "components/video-relay-service-component";
+
 
 @import "objects/grid";
 @import "shared/embed_codes";

--- a/app/assets/stylesheets/components/_video-relay-service-component.scss
+++ b/app/assets/stylesheets/components/_video-relay-service-component.scss
@@ -1,0 +1,7 @@
+.app-c-content-block-manager-video-relay-service-component {
+  textarea#edition_details_telephones_video_relay_service_prefix {
+    height: govuk-spacing(7);
+    resize: none;
+  }
+}
+


### PR DESCRIPTION
At present we use a Govspeak-enabled textarea as we understand that users need to include an HTML link using markdown e.g. `[Relay UK](https://www.relayuk.bt.com)`. 

<img width="1230" height="406" alt="vrs_prefix_as_is" src="https://github.com/user-attachments/assets/773d4829-26f3-4f09-9ada-785e385b0477" />

But we understand that it's not appropriate to offer a regular textarea here as we need to communicate to users that the content should fit on a single line.

We currently only support Govspeak on textareas so the fix proposed is to style the Govspeak-enabled textarea to be a single line. In this draft commit we:

- set the textarea height to govuk-spacing(7) which is 40px. This is also the defined minimum-height of govuk textareas
- disable resizing of the textarea

<img width="1261" height="327" alt="video_relay_service_prefix_edit_mode" src="https://github.com/user-attachments/assets/ae4bf194-6520-4af8-982a-788500d5673b" />

However, in a desk review we questioned whether in addition we'd need to disable the "return/enter" key to prevent the user adding line breaks? Otherwise multiple line content can be added but invisible. Furthermore, if multiline
content is then saved, only the first line will then be visible when the form is rendered for editing.

An alternative might be to implement a Govspeak-enabled text input but this is a more significant piece of work. Do we anticipate other scenarios where we need a single line textarea?

Is it worth considering a two-line textarea? This might have the advantage of:

- being equally effective at communicating that we expect a small amount of content, but
- also providing more functionality if the user does enter line breaks: they will be able to see the second line and have access to a minimal scroll bar.

<img width="1233" height="347" alt="vrl_2_line_textarea" src="https://github.com/user-attachments/assets/33f2b761-7933-4652-85f0-61d265ac717c" />
