### PR TITLE
(CM-528) Show translated address labels

### DIFF
--- a/app/components/document/show/embedded_objects/blocks_component.rb
+++ b/app/components/document/show/embedded_objects/blocks_component.rb
@@ -32,7 +32,7 @@ private
   def attribute_rows(key_name = :key)
     first_class_items(items).map do |key, value|
       {
-        "#{key_name}": key_to_title(key, schema_name),
+        "#{key_name}": key_to_label(key, schema_name),
         value: content_for_row(key, value),
         data: data_attributes_for_row(key),
       }
@@ -68,7 +68,7 @@ private
   def rows_for_nested_items(items, nested_name, index)
     items.map do |key, value|
       {
-        key: key_to_title(key, schema_name, "#{object_type}.#{nested_name}"),
+        key: key_to_label(key, schema_name, "#{object_type}.#{nested_name}"),
         value: content_for_row(embed_code_identifier(nested_name, index, key), translated_value(key, value)),
         data: data_attributes_for_row(embed_code_identifier(nested_name, index, key)),
       }

--- a/app/components/shared/embedded_objects/summary_card_component.html.erb
+++ b/app/components/shared/embedded_objects/summary_card_component.html.erb
@@ -21,7 +21,7 @@
           items,
           object_key: key,
           object_type:,
-          title: nested_item_title(key),
+          title: key_to_title(key, edition.schema.block_type, schema.id),
           subschema: schema,
           root_schema_name: root_schema.block_type,
         ) %>
@@ -30,7 +30,7 @@
           nested_items: items,
           object_key: key,
           object_type:,
-          title: nested_item_title(key),
+          title: key_to_title(key, edition.schema.block_type, schema.id),
           subschema: schema,
           root_schema_name: root_schema.block_type,
         ) %>

--- a/app/components/shared/embedded_objects/summary_card_component.rb
+++ b/app/components/shared/embedded_objects/summary_card_component.rb
@@ -24,10 +24,6 @@ private
     "#{object_type.titleize.singularize.capitalize} details"
   end
 
-  def nested_item_title(key)
-    I18n.t("edition.titles.#{edition.schema.block_type}.#{schema.id}.#{key}", default: key.singularize.titleize)
-  end
-
   def items
     schema.fields.map { |field|
       [field.name, object[field.name]]

--- a/app/components/shared/embedded_objects/summary_card_component.rb
+++ b/app/components/shared/embedded_objects/summary_card_component.rb
@@ -33,7 +33,7 @@ private
   def rows
     first_class_items(items).map do |key, value|
       {
-        field: key_to_label(key, object_type),
+        field: key_to_label(key, edition.schema.block_type, object_type),
         value: translated_value(key, value),
         data: {
           testid: [object_title.parameterize, key].compact.join("_").underscore,

--- a/app/components/shared/embedded_objects/summary_card_component.rb
+++ b/app/components/shared/embedded_objects/summary_card_component.rb
@@ -37,7 +37,7 @@ private
   def rows
     first_class_items(items).map do |key, value|
       {
-        field: key_to_title(key, object_type),
+        field: key_to_label(key, object_type),
         value: translated_value(key, value),
         data: {
           testid: [object_title.parameterize, key].compact.join("_").underscore,

--- a/app/helpers/summary_list_helper.rb
+++ b/app/helpers/summary_list_helper.rb
@@ -24,20 +24,19 @@ module SummaryListHelper
   end
 
   def key_to_label(key, schema_name, object_type = nil)
-    subject, count = key.split("/")
-    if count
-      humanized_label(schema_name:, relative_key: "#{subject.singularize} #{count.to_i + 1}", root_object: object_type)
-    else
-      humanized_label(schema_name:, relative_key: subject, root_object: object_type)
-    end
+    relative_key = parse_key(key)
+    humanized_label(schema_name:, relative_key:, root_object: object_type)
   end
 
   def key_to_title(key, schema_name, object_type = nil)
+    relative_key = parse_key(key)
+    humanized_title(schema_name:, relative_key:, root_object: object_type)
+  end
+
+private
+
+  def parse_key(key)
     subject, count = key.split("/")
-    if count
-      humanized_title(schema_name:, relative_key: "#{subject.singularize} #{count.to_i + 1}", root_object: object_type)
-    else
-      humanized_title(schema_name:, relative_key: subject, root_object: object_type)
-    end
+    count ? "#{subject.singularize} #{count.to_i + 1}" : subject
   end
 end

--- a/app/helpers/summary_list_helper.rb
+++ b/app/helpers/summary_list_helper.rb
@@ -31,4 +31,13 @@ module SummaryListHelper
       humanized_label(schema_name:, relative_key: subject, root_object: object_type)
     end
   end
+
+  def key_to_title(key, schema_name, object_type = nil)
+    subject, count = key.split("/")
+    if count
+      humanized_title(schema_name:, relative_key: "#{subject.singularize} #{count.to_i + 1}", root_object: object_type)
+    else
+      humanized_title(schema_name:, relative_key: subject, root_object: object_type)
+    end
+  end
 end

--- a/app/helpers/summary_list_helper.rb
+++ b/app/helpers/summary_list_helper.rb
@@ -23,7 +23,7 @@ module SummaryListHelper
     end
   end
 
-  def key_to_title(key, schema_name, object_type = nil)
+  def key_to_label(key, schema_name, object_type = nil)
     subject, count = key.split("/")
     if count
       humanized_label(schema_name:, relative_key: "#{subject.singularize} #{count.to_i + 1}", root_object: object_type)

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -12,6 +12,19 @@ module TranslationHelper
     )
   end
 
+  def humanized_title(schema_name:, relative_key:, root_object: nil)
+    translation_path = [
+      schema_name,
+      root_object,
+      relative_key,
+    ].compact.join(".")
+
+    I18n.t(
+      "edition.titles.#{translation_path}",
+      default: relative_key.humanize.gsub("-", " "),
+    )
+  end
+
   def translated_value(key, value)
     default_path = "edition.values.#{value}"
     translation_path = "edition.values.#{key}.#{value}"

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -1,28 +1,10 @@
 module TranslationHelper
   def humanized_label(schema_name:, relative_key:, root_object: nil)
-    translation_path = [
-      schema_name,
-      root_object,
-      relative_key,
-    ].compact.join(".")
-
-    I18n.t(
-      "edition.labels.#{translation_path}",
-      default: relative_key.humanize.gsub("-", " "),
-    )
+    humanized_translation(schema_name:, relative_key:, root_object:, scope: "labels")
   end
 
   def humanized_title(schema_name:, relative_key:, root_object: nil)
-    translation_path = [
-      schema_name,
-      root_object,
-      relative_key,
-    ].compact.join(".")
-
-    I18n.t(
-      "edition.titles.#{translation_path}",
-      default: relative_key.humanize.gsub("-", " "),
-    )
+    humanized_translation(schema_name:, relative_key:, root_object:, scope: "titles")
   end
 
   def translated_value(key, value)
@@ -44,5 +26,20 @@ module TranslationHelper
     ].compact.join(".")
 
     I18n.t("edition.hints.#{translation_lookup}", default: nil)
+  end
+
+private
+
+  def humanized_translation(schema_name:, relative_key:, root_object:, scope:)
+    translation_path = [
+      schema_name,
+      root_object,
+      relative_key,
+    ].compact.join(".")
+
+    I18n.t(
+      "edition.#{scope}.#{translation_path}",
+      default: relative_key.humanize.gsub("-", " "),
+    )
   end
 end

--- a/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -84,9 +84,9 @@ class Shared::EmbeddedObjects::SummaryCardComponentTest < ViewComponent::TestCas
 
   describe "when there is a translated value" do
     it "returns a translated value" do
-      I18n.expects(:t).with("edition.labels.embedded-objects.name", default: "Name").returns("Name")
-      I18n.expects(:t).with("edition.labels.embedded-objects.field-1", default: "Field 1").returns("Field 1")
-      I18n.expects(:t).with("edition.labels.embedded-objects.field-2", default: "Field 2").returns("Field 2")
+      I18n.expects(:t).with("edition.labels.block_type.embedded-objects.name", default: "Name").returns("Name")
+      I18n.expects(:t).with("edition.labels.block_type.embedded-objects.field-1", default: "Field 1").returns("Field 1")
+      I18n.expects(:t).with("edition.labels.block_type.embedded-objects.field-2", default: "Field 2").returns("Field 2")
 
       component = Shared::EmbeddedObjects::SummaryCardComponent.new(
         edition:,
@@ -288,7 +288,7 @@ class Shared::EmbeddedObjects::SummaryCardComponentTest < ViewComponent::TestCas
           object_title: "my-embedded-object",
         )
 
-        component.expects(:key_to_label).with("name", "embedded-objects").returns("Name translated")
+        component.expects(:key_to_label).with("name", "block_type", "embedded-objects").returns("Name translated")
         component.expects(:translated_value).with("name", "My Embedded Object").returns("My Embedded Object translated")
 
         I18n.expects(:t).with("edition.titles.#{edition.schema.block_type}.#{subschema.id}.field", default: "Field").returns("Field translated")

--- a/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -288,7 +288,7 @@ class Shared::EmbeddedObjects::SummaryCardComponentTest < ViewComponent::TestCas
           object_title: "my-embedded-object",
         )
 
-        component.expects(:key_to_title).with("name", "embedded-objects").returns("Name translated")
+        component.expects(:key_to_label).with("name", "embedded-objects").returns("Name translated")
         component.expects(:translated_value).with("name", "My Embedded Object").returns("My Embedded Object translated")
 
         I18n.expects(:t).with("edition.titles.#{edition.schema.block_type}.#{subschema.id}.field", default: "Field").returns("Field translated")

--- a/test/unit/app/helpers/summary_list_helper_test.rb
+++ b/test/unit/app/helpers/summary_list_helper_test.rb
@@ -77,4 +77,22 @@ class SummaryListHelperTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#key_to_title" do
+    it "returns a titlelized version of a key without an index" do
+      assert_equal key_to_title("item", "schema_name"), "Item"
+    end
+
+    it "returns a titleized version with a count when an index is present" do
+      assert_equal key_to_title("items/1", "schema_name"), "Item 2"
+    end
+
+    describe "when there is a translation for the key" do
+      it "returns translated key" do
+        I18n.expects(:t).with("edition.titles.schema_name.object_type.item", default: "Item").returns("Item translated")
+
+        assert_equal key_to_title("item", "schema_name", "object_type"), "Item translated"
+      end
+    end
+  end
 end

--- a/test/unit/app/helpers/summary_list_helper_test.rb
+++ b/test/unit/app/helpers/summary_list_helper_test.rb
@@ -60,20 +60,20 @@ class SummaryListHelperTest < ActiveSupport::TestCase
     end
   end
 
-  describe "#key_to_title" do
+  describe "#key_to_label" do
     it "returns a titlelized version of a key without an index" do
-      assert_equal key_to_title("item", "schema_name"), "Item"
+      assert_equal key_to_label("item", "schema_name"), "Item"
     end
 
     it "returns a titleized version with a count when an index is present" do
-      assert_equal key_to_title("items/1", "schema_name"), "Item 2"
+      assert_equal key_to_label("items/1", "schema_name"), "Item 2"
     end
 
     describe "when there is a translation for the key" do
       it "returns translated key" do
         I18n.expects(:t).with("edition.labels.schema_name.object_type.item", default: "Item").returns("Item translated")
 
-        assert_equal key_to_title("item", "schema_name", "object_type"), "Item translated"
+        assert_equal key_to_label("item", "schema_name", "object_type"), "Item translated"
       end
     end
   end


### PR DESCRIPTION
# Description

As per [CM-528](https://gov-uk.atlassian.net/browse/CM-528) the `Address name` field was still showing as `Title` in some places. This attempts to fix that.

We had a method on the summary card component called `nested_item_title` which I've removed in favour of replicating some of the functionality that's in this `TranslationHelper` to work with titles and labels in the same way.

The actual fix here is really just a one-line change in this component.

# Testing Steps

- In your locally running CBM
- Go to the Edit screen of a contact with an address (e.g. `/editions/:id/workflow/group_contact_methods`)
  - Observe that the text on the name of the address is `Address Name` and not `Title`
- Go to the Edit screen of a contact with a Telephone contact that has multiple (nested) phone numbers
  - Observe that these blocks are labelled `Telephone number 1`, `Telephone number 2` etc and that this is not broken.


Example correctly rendering blocks:
<img width="1029" height="940" alt="Screenshot 2025-10-08 at 14 19 27" src="https://github.com/user-attachments/assets/1263beca-65b8-4717-8f04-844804422b08" />
<img width="1059" height="678" alt="Screenshot 2025-10-08 at 14 19 20" src="https://github.com/user-attachments/assets/5ee53ae5-cfd5-4b88-9d8f-376355f816fb" />




[CM-528]: https://gov-uk.atlassian.net/browse/CM-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ