### PR TITLE
Experimental: Use ActiveRecord models rather than JSONSchema to model block types

### DIFF
--- a/app/controllers/block/documents_controller.rb
+++ b/app/controllers/block/documents_controller.rb
@@ -1,0 +1,7 @@
+module Block
+  class DocumentsController < ApplicationController
+    def index
+      @editions = Block::Document.all.map { |document| document.editions.last }
+    end
+  end
+end

--- a/app/controllers/block/time_period_date_ranges_controller.rb
+++ b/app/controllers/block/time_period_date_ranges_controller.rb
@@ -1,9 +1,38 @@
 module Block
   class TimePeriodDateRangesController < ApplicationController
+    before_action :set_document
+    before_action :set_edition
+
     def show; end
 
     def edit; end
 
-    def update; end
+    def update
+      if @edition.update(edition_params)
+        redirect_to block_document_time_period_date_range_path(
+          @document,
+          @edition,
+        ),
+                    notice: "Time period was successfully updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+  private
+
+    def set_document
+      @document = Block::Document.find(params[:document_id])
+    end
+
+    def set_edition
+      @edition = @document.time_period_editions.find(params[:id])
+    end
+
+    def edition_params
+      params.require(:edition).permit(
+        date_range_attributes: %i[id start end],
+      )
+    end
   end
 end

--- a/app/controllers/block/time_period_date_ranges_controller.rb
+++ b/app/controllers/block/time_period_date_ranges_controller.rb
@@ -1,0 +1,9 @@
+module Block
+  class TimePeriodDateRangesController < ApplicationController
+    def show; end
+
+    def edit; end
+
+    def update; end
+  end
+end

--- a/app/controllers/block/time_period_date_ranges_controller.rb
+++ b/app/controllers/block/time_period_date_ranges_controller.rb
@@ -9,11 +9,7 @@ module Block
 
     def update
       if @edition.update(edition_params)
-        redirect_to block_document_time_period_date_range_path(
-          @document,
-          @edition,
-        ),
-                    notice: "Time period was successfully updated."
+        redirect_to block_time_period_edition_path(@edition)
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -1,13 +1,48 @@
 module Block
   class TimePeriodEditionsController < ApplicationController
-    def new; end
+    before_action :set_edition, only: %i[show edit update]
+    before_action :set_organisations, only: %i[new create]
 
-    def create; end
+    def new
+      @edition = Block::TimePeriodEdition.new
+      @edition.build_document(block_type: "time_period")
+    end
+
+    def create
+      @edition = Block::TimePeriodEdition.new(edition_params)
+      @edition.build_document(block_type: "time_period") unless @edition.document
+
+      if @edition.save
+        redirect_to block_time_period_edition_path(@edition)
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
 
     def show; end
 
     def edit; end
 
     def update; end
+
+  private
+
+    def set_edition
+      @edition = Block::TimePeriodEdition.find(params[:id])
+    end
+
+    def set_organisations
+      @organisations = [{ text: "", value: "" }] +
+        Organisation.all.map { |org| { text: org.name, value: org.id } }
+    end
+
+    def edition_params
+      params.require(:edition).permit(
+        :title,
+        :description,
+        :instructions_to_publishers,
+        :lead_organisation_id,
+      )
+    end
   end
 end

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -1,0 +1,13 @@
+module Block
+  class TimePeriodEditionsController < ApplicationController
+    def new; end
+
+    def create; end
+
+    def show; end
+
+    def edit; end
+
+    def update; end
+  end
+end

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -13,7 +13,10 @@ module Block
       @edition.build_document(block_type: "time_period") unless @edition.document
 
       if @edition.save
-        redirect_to block_time_period_edition_path(@edition)
+        redirect_to edit_block_document_time_period_date_range_path(
+          @edition.document,
+          @edition,
+        )
       else
         render :new, status: :unprocessable_entity
       end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -1,0 +1,36 @@
+module Block
+  class Document < ApplicationRecord
+    self.table_name = "block_documents"
+
+    extend FriendlyId
+    friendly_id :sluggable_string, use: :slugged, slug_column: :content_id_alias, routes: :default
+
+    has_many :editions, class_name: "Block::Edition", foreign_key: :block_document_id, dependent: :destroy
+
+    before_validation :generate_content_id, on: :create
+    after_validation :set_content_id_alias_and_embed_code, on: :create
+
+    def title
+      editions.order(created_at: :desc).first&.title
+    end
+
+    def built_embed_code
+      "{{embed:content_block_#{block_type}:#{content_id_alias}}}"
+    end
+
+    def embed_code_for_field(field_path)
+      "{{embed:content_block_#{block_type}:#{content_id_alias}/#{field_path}}}"
+    end
+
+  private
+
+    def generate_content_id
+      self.content_id ||= SecureRandom.uuid
+    end
+
+    def set_content_id_alias_and_embed_code
+      self.content_id_alias = friendly_id
+      self.embed_code = built_embed_code
+    end
+  end
+end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -5,7 +5,18 @@ module Block
     extend FriendlyId
     friendly_id :sluggable_string, use: :slugged, slug_column: :content_id_alias, routes: :default
 
-    has_many :editions, class_name: "Block::Edition", foreign_key: :block_document_id, dependent: :destroy
+    has_many :editions,
+             class_name: "Block::Edition",
+             foreign_key: :block_document_id,
+             dependent: :destroy,
+             inverse_of: :document
+
+    has_many :time_period_editions,
+             -> { where(type: "Block::TimePeriodEdition") },
+             class_name: "Block::TimePeriodEdition",
+             foreign_key: :block_document_id,
+             dependent: :destroy,
+             inverse_of: :document
 
     before_validation :generate_content_id, on: :create
     after_validation :set_content_id_alias_and_embed_code, on: :create

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -17,6 +17,14 @@ module Block
       raise NotImplementedError, "Subclasses must implement #details method"
     end
 
+    def state
+      :draft
+    end
+
+    def creator
+      User.first
+    end
+
   private
 
     def set_document_sluggable_string

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -1,7 +1,6 @@
 module Block
   class Edition < ApplicationRecord
     self.table_name = "block_editions"
-    self.abstract_class = true
 
     belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id
 

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -2,10 +2,11 @@ module Block
   class Edition < ApplicationRecord
     self.table_name = "block_editions"
 
+    include ::Edition::HasLeadOrganisation
+
     belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id, inverse_of: :editions
 
     validates :title, presence: true
-    validates :lead_organisation_id, presence: true
     validate :title_contains_alphanumeric_chars
 
     before_validation :set_document_sluggable_string, on: :create

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -1,0 +1,16 @@
+module Block
+  class Edition < ApplicationRecord
+    self.table_name = "block_editions"
+    self.abstract_class = true
+
+    belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id
+
+    validates :title, presence: true
+
+    # Abstract method to be implemented by subclasses
+    # Returns a hash representation of the edition's details
+    def details
+      raise NotImplementedError, "Subclasses must implement #details method"
+    end
+  end
+end

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -2,14 +2,32 @@ module Block
   class Edition < ApplicationRecord
     self.table_name = "block_editions"
 
-    belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id
+    belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id, inverse_of: :editions
 
     validates :title, presence: true
+    validates :lead_organisation_id, presence: true
+    validate :title_contains_alphanumeric_chars
+
+    before_validation :set_document_sluggable_string, on: :create
 
     # Abstract method to be implemented by subclasses
     # Returns a hash representation of the edition's details
     def details
       raise NotImplementedError, "Subclasses must implement #details method"
+    end
+
+  private
+
+    def set_document_sluggable_string
+      return unless document.present? && document.new_record?
+
+      document.sluggable_string = title if document.sluggable_string.blank?
+    end
+
+    def title_contains_alphanumeric_chars
+      if title.present? && title !~ /[a-z0-9]+/i
+        errors.add(:title, :alphanumeric)
+      end
     end
   end
 end

--- a/app/models/block/other_edition.rb
+++ b/app/models/block/other_edition.rb
@@ -1,0 +1,8 @@
+module Block
+  # Stub edition class for testing STI scoping behavior
+  class OtherEdition < Edition
+    def details
+      { type: "other" }
+    end
+  end
+end

--- a/app/models/block/time_period_date_range.rb
+++ b/app/models/block/time_period_date_range.rb
@@ -1,0 +1,34 @@
+module Block
+  class TimePeriodDateRange < ApplicationRecord
+    self.table_name = "block_time_period_date_ranges"
+
+    belongs_to :edition, class_name: "Block::TimePeriodEdition"
+
+    validates :start, presence: true
+    validates :end, presence: true
+    validate :end_date_after_start_date
+
+    def to_details
+      {
+        "start" => {
+          "date" => start.strftime("%Y-%m-%d"),
+          "time" => start.strftime("%H:%M"),
+        },
+        "end" => {
+          "date" => self.end.strftime("%Y-%m-%d"),
+          "time" => self.end.strftime("%H:%M"),
+        },
+      }
+    end
+
+  private
+
+    def end_date_after_start_date
+      return if self.end.blank? || start.blank?
+
+      if self.end <= start
+        errors.add(:end, "must be after start date")
+      end
+    end
+  end
+end

--- a/app/models/block/time_period_date_range.rb
+++ b/app/models/block/time_period_date_range.rb
@@ -2,6 +2,9 @@ module Block
   class TimePeriodDateRange < ApplicationRecord
     self.table_name = "block_time_period_date_ranges"
 
+    include DateValidation
+    date_attributes :start, :end
+
     belongs_to :edition, class_name: "Block::TimePeriodEdition"
 
     validates :start, presence: true

--- a/app/models/block/time_period_edition.rb
+++ b/app/models/block/time_period_edition.rb
@@ -1,0 +1,5 @@
+module Block
+  class TimePeriodEdition < Edition
+    # Minimal STI subclass - associations and #details method added in later commit
+  end
+end

--- a/app/models/block/time_period_edition.rb
+++ b/app/models/block/time_period_edition.rb
@@ -1,5 +1,14 @@
 module Block
   class TimePeriodEdition < Edition
-    # Minimal STI subclass - associations and #details method added in later commit
+    has_one :date_range, class_name: "Block::TimePeriodDateRange", foreign_key: :edition_id, dependent: :destroy
+
+    accepts_nested_attributes_for :date_range
+
+    def details
+      {
+        "description" => description,
+        "date_range" => date_range&.to_details,
+      }.compact
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   module Permissions
     SIGNIN = "signin".freeze
     PRE_RELEASE_FEATURES_PERMISSION = "pre_release_features".freeze
+    SCHEMALESS_EXPERIMENT_PERMISSION = "schemaless_experiment".freeze
     SHOW_ALL_CONTENT_BLOCK_TYPES = "show_all_content_block_types".freeze
   end
 

--- a/app/public/helpers/application_helper.rb
+++ b/app/public/helpers/application_helper.rb
@@ -13,6 +13,13 @@ module ApplicationHelper
     false
   end
 
+  def schemaless_experiment_enabled?
+    return true if current_user&.has_permission?(User::Permissions::SCHEMALESS_EXPERIMENT_PERMISSION)
+    return true if params[:schemaless_experiment] == "true"
+
+    false
+  end
+
   def get_content_id(edition)
     return if edition.nil?
 

--- a/app/public/helpers/header_helper.rb
+++ b/app/public/helpers/header_helper.rb
@@ -7,8 +7,14 @@ module HeaderHelper
     }
   end
 
-  def navigation_items(current_user)
+  def navigation_items(current_user, schemaless_experiment_enabled: false)
     return [] if current_user.nil?
+
+    if schemaless_experiment_enabled
+      return [
+        main_nav_item("New-style blocks", block_documents_path),
+      ]
+    end
 
     [
       main_nav_item("Blocks", root_path),

--- a/app/views/block/documents/index.html.erb
+++ b/app/views/block/documents/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, "New-style blocks" %>
+
+<div class="govuk-grid-row content-block-manager-header">
+  <div class="govuk-grid-column-one-half">
+    <h1 class="govuk-heading-xl content-block-manager-header--heading">
+      New-style blocks
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% @editions.each_with_index do |edition, index| %>
+      <div data-testid="homepage-item-<%= index %>">
+        <%= render "govuk_publishing_components/components/summary_card", {
+          title: edition.title,
+          rows: [
+            {
+              key: "Time period name",
+              value: edition.title,
+            },
+            {
+              key: "Lead organisation",
+              value: edition.lead_organisation.name,
+            },
+            {
+              key: "Status",
+              value: render(Shared::DocumentFullStatusComponent.new(edition: edition)),
+            },
+
+          ],
+          summary_card_actions: [
+            {
+              label: "View",
+              href: block_time_period_edition_path(edition),
+            },
+          ],
+        } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/block/time_period_date_ranges/_form.html.erb
+++ b/app/views/block/time_period_date_ranges/_form.html.erb
@@ -1,0 +1,211 @@
+<%= form_with(
+  model: @edition,
+  url: @edition.persisted? ?
+    block_document_time_period_date_range_path(@document, @edition) :
+    block_document_time_period_date_ranges_path(@document),
+  method: @edition.persisted? ? :patch : :post,
+) do |f| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h2 class="govuk-fieldset__heading">Date range</h2>
+      </legend>
+
+      <%= f.fields_for :date_range,
+          @edition.date_range || @edition.build_date_range do |dr_fields| %>
+
+        <%# START datetime %>
+        <div class="govuk-form-group">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "Start",
+            heading_level: 3,
+            heading_size: "s",
+          } do %>
+            <%= render "govuk_publishing_components/components/date_input", {
+              hint: "For example, 27 3 2025",
+              error_items: errors_for(
+                @edition.date_range&.errors || [],
+                :start,
+              ),
+              items: [
+                {
+                  label: "Day",
+                  name: "edition[date_range_attributes][start(3i)]",
+                  value: @edition.date_range&.start&.day,
+                  width: 2,
+                },
+                {
+                  label: "Month",
+                  name: "edition[date_range_attributes][start(2i)]",
+                  value: @edition.date_range&.start&.month,
+                  width: 2,
+                },
+                {
+                  label: "Year",
+                  name: "edition[date_range_attributes][start(1i)]",
+                  value: @edition.date_range&.start&.year,
+                  width: 4,
+                },
+              ],
+            } %>
+
+            <div class="govuk-form-group"
+                 style="margin-top: 20px;">
+              <%= render "govuk_publishing_components/components/fieldset", {
+                legend_text: "Time",
+                heading_level: 4,
+                heading_size: "s",
+              } do %>
+                <div class="govuk-hint">For example, 09:30 or 19:30</div>
+                <div style="display: flex;
+                            align-items: flex-end;
+                            gap: 10px;">
+                  <div>
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Hour",
+                        html_for: "start_hour",
+                      }
+                    ) %>
+                    <%= select_hour(
+                      @edition.date_range&.start&.hour,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "start(4i)",
+                      },
+                      {
+                        id: "start_hour",
+                        class: "govuk-select",
+                      },
+                    ) %>
+                  </div>
+                  <div style="padding-bottom: 5px;">:</div>
+                  <div>
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Minute",
+                        html_for: "start_minute",
+                      }
+                    ) %>
+                    <%= select_minute(
+                      @edition.date_range&.start&.min,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "start(5i)",
+                      },
+                      {
+                        id: "start_minute",
+                        class: "govuk-select",
+                      },
+                    ) %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+        <%# END datetime %>
+        <div class="govuk-form-group">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "End",
+            heading_level: 3,
+            heading_size: "s",
+          } do %>
+            <%= render "govuk_publishing_components/components/date_input", {
+              hint: "For example, 31 3 2025",
+              error_items: errors_for(
+                @edition.date_range&.errors || [],
+                :end,
+              ),
+              items: [
+                {
+                  label: "Day",
+                  name: "edition[date_range_attributes][end(3i)]",
+                  value: @edition.date_range&.end&.day,
+                  width: 2,
+                },
+                {
+                  label: "Month",
+                  name: "edition[date_range_attributes][end(2i)]",
+                  value: @edition.date_range&.end&.month,
+                  width: 2,
+                },
+                {
+                  label: "Year",
+                  name: "edition[date_range_attributes][end(1i)]",
+                  value: @edition.date_range&.end&.year,
+                  width: 4,
+                },
+              ],
+            } %>
+
+            <div class="govuk-form-group"
+                 style="margin-top: 20px;">
+              <%= render "govuk_publishing_components/components/fieldset", {
+                legend_text: "Time",
+                heading_level: 4,
+                heading_size: "s",
+              } do %>
+                <div class="govuk-hint">For example, 09:30 or 19:30</div>
+                <div style="display: flex;
+                            align-items: flex-end;
+                            gap: 10px;">
+                  <div>
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Hour",
+                        html_for: "end_hour",
+                      }
+                    ) %>
+                    <%= select_hour(
+                      @edition.date_range&.end&.hour,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "end(4i)",
+                      },
+                      {
+                        id: "end_hour",
+                        class: "govuk-select",
+                      },
+                    ) %>
+                  </div>
+                  <div style="padding-bottom: 5px;">:</div>
+                  <div>
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Minute",
+                        html_for: "end_minute",
+                      }
+                    ) %>
+                    <%= select_minute(
+                      @edition.date_range&.end&.min,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "end(5i)",
+                      },
+                      {
+                        id: "end_minute",
+                        class: "govuk-select",
+                      },
+                    ) %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+      <% end %>
+    </fieldset>
+  </div>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save and continue",
+    type: "submit",
+  } %>
+<% end %>

--- a/app/views/block/time_period_date_ranges/edit.html.erb
+++ b/app/views/block/time_period_date_ranges/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Edit time period block" %>
+<% content_for :back_link,
+   render("govuk_publishing_components/components/back_link", {
+     href: block_document_time_period_date_range_path(@document, @edition),
+   }) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/block/time_period_date_ranges/show.html.erb
+++ b/app/views/block/time_period_date_ranges/show.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, @edition.title %>
+<% content_for :back_link,
+   render("govuk_publishing_components/components/back_link", {
+     href: "#", # TODO: Link to time periods index
+   }) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: "Block details",
+      items: [
+        {
+          field: "Description",
+          value: @edition.description || "No description provided",
+        },
+        {
+          field: "Start date",
+          value: @edition.date_range&.start || "Not set",
+        },
+        {
+          field: "End date",
+          value: @edition.date_range&.end || "Ongoing",
+        },
+        {
+          field: "Embed code",
+          value: "<code>#{@document.embed_code}</code>".html_safe,
+        },
+      ],
+    } %>
+
+    <div class="govuk-button-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Edit",
+        href: edit_block_document_time_period_date_range_path(
+          @document,
+          @edition,
+        ),
+      } %>
+    </div>
+  </div>
+</div>

--- a/app/views/block/time_period_editions/_form.html.erb
+++ b/app/views/block/time_period_editions/_form.html.erb
@@ -1,0 +1,52 @@
+<% content_for :error_summary, render(Shared::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+
+<%= form_with(
+  model: @edition,
+  url: @edition.persisted? ?
+    block_time_period_edition_path(@edition) :
+    block_time_period_editions_path,
+  method: @edition.persisted? ? :patch : :post,
+) do |f| %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Title",
+    },
+    name: "edition[title]",
+    value: @edition.title,
+    error_items: errors_for(@edition.errors, :title),
+  } %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: "Description",
+    },
+    name: "edition[description]",
+    value: @edition.description,
+    error_items: errors_for(@edition.errors, :description),
+    rows: 3,
+  } %>
+
+  <%= render "govuk_publishing_components/components/select", {
+    id: "edition_lead_organisation_id",
+    name: "edition[lead_organisation_id]",
+    label: "Lead organisation",
+    options: @organisations,
+    error_items: errors_for(@edition.errors, :lead_organisation_id),
+  } %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: "Instructions to publishers",
+    },
+    name: "edition[instructions_to_publishers]",
+    value: @edition.instructions_to_publishers,
+    error_items: errors_for(@edition.errors, :instructions_to_publishers),
+    rows: 3,
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save and continue",
+    type: "submit",
+  } %>
+<% end %>

--- a/app/views/block/time_period_editions/edit.html.erb
+++ b/app/views/block/time_period_editions/edit.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, "Edit time period" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/block/time_period_editions/new.html.erb
+++ b/app/views/block/time_period_editions/new.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, "Create time period block" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/block/time_period_editions/show.html.erb
+++ b/app/views/block/time_period_editions/show.html.erb
@@ -1,8 +1,56 @@
-<% content_for :title, "Time period edition" %>
+<% content_for :title, @edition.title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= @edition.title %></h1>
-    <p class="govuk-body">Edition created. Next step: add the date range.</p>
+    <%= render "govuk_publishing_components/components/summary_list", {
+      items: [
+        {
+          field: "Title",
+          value: @edition.title,
+        },
+        {
+          field: "Description",
+          value: @edition.description,
+        },
+        {
+          field: "Instructions to publishers",
+          value: @edition.instructions_to_publishers,
+        },
+        {
+          field: "Embed code",
+          value: "<code>#{@edition.document.embed_code}</code>".html_safe,
+        },
+      ].compact,
+    } %>
+
+    <% if @edition.date_range %>
+      <%= render "govuk_publishing_components/components/summary_list", {
+        title: "Date range",
+        items: [
+          {
+            field: "Start date",
+            value: ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+                      @edition.date_range.start.to_s,
+                    ).render,
+          },
+          {
+            field: "End date",
+            value: ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+                      @edition.date_range.end.to_s,
+                    ).render,
+          },
+        ],
+      } %>
+    <% end %>
+
+    <div class="govuk-button-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Edit time period",
+        href: edit_block_document_time_period_date_range_path(
+          @edition.document,
+          @edition,
+        ),
+      } %>
+    </div>
   </div>
 </div>

--- a/app/views/block/time_period_editions/show.html.erb
+++ b/app/views/block/time_period_editions/show.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Time period edition" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @edition.title %></h1>
+    <p class="govuk-body">Edition created. Next step: add the date range.</p>
+  </div>
+</div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -19,12 +19,23 @@
       <p class="govuk-body">Create, edit and use standardised content across GOV.UK</p>
     </div>
     <div class="govuk-grid-column-one-half content-block-manager-header--column-right">
-      <div>
+      <ul class="govuk-list govuk-!-text-align-centre">
+        <li class="govuk-!-static-margin-bottom-3">
           <%= render "govuk_publishing_components/components/button", {
             text: "Create content block",
             href: new_document_path,
           } %>
-      </div>
+        </li>
+        <% if schemaless_experiment_enabled? %>
+          <li>
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Create new-style block",
+              href: new_block_time_period_edition_path,
+              secondary_solid: true,
+            } %>
+          </li>
+      <% end %>
+      </ul>
     </div>
 </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,5 +6,5 @@
   product_name: ContentBlockManager.product_name,
   environment: environment,
   logo_link: root_path,
-  navigation_items: navigation_items(current_user),
+  navigation_items: navigation_items(current_user, schemaless_experiment_enabled: schemaless_experiment_enabled?),
 } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,14 @@ en:
               alphanumeric: "must contain at least one letter or number"
             lead_organisation_id:
               blank: "cannot be blank"
+        block/time_period_date_range:
+          attributes:
+            start:
+              blank: "Enter a start date"
+              invalid_date: "Start date is not a valid date"
+            end:
+              blank: "Enter an end date"
+              invalid_date: "End date is not a valid date"
     attributes:
       edition/document:
         title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,13 @@ en:
             url:
               blank: "URL cannot be blank"
               invalid: "URL is invalid"
+        block/edition:
+          attributes:
+            title:
+              blank: "cannot be blank"
+              alphanumeric: "must contain at least one letter or number"
+            lead_organisation_id:
+              blank: "cannot be blank"
     attributes:
       edition/document:
         title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,11 @@ Rails.application.routes.draw do
     put "schedule", to: "documents/schedule#update", as: :update_schedule
     patch "schedule", to: "documents/schedule#update"
   end
+  # Block namespace - experimental ActiveRecord architecture
+  namespace :block do
+    resources :time_period_editions, only: %i[new create show edit update]
+  end
+
   resources :editions, only: %i[new create destroy], path_names: { new: ":block_type/new" } do
     member do
       get :preview, to: "editions#preview"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,12 @@ Rails.application.routes.draw do
   # Block namespace - experimental ActiveRecord architecture
   namespace :block do
     resources :time_period_editions, only: %i[new create show edit update]
+
+    resources :documents, only: [] do
+      resources :time_period_date_ranges,
+                only: %i[edit update show],
+                path: "time-period-date-ranges"
+    end
   end
 
   resources :editions, only: %i[new create destroy], path_names: { new: ":block_type/new" } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   namespace :block do
     resources :time_period_editions, only: %i[new create show edit update]
 
-    resources :documents, only: [] do
+    resources :documents, only: [:index] do
       resources :time_period_date_ranges,
                 only: %i[edit update show],
                 path: "time-period-date-ranges"

--- a/db/migrate/20260311174532_create_block_documents.rb
+++ b/db/migrate/20260311174532_create_block_documents.rb
@@ -1,0 +1,19 @@
+class CreateBlockDocuments < ActiveRecord::Migration[8.1]
+  def change
+    create_table :block_documents do |t|
+      t.uuid :content_id, null: false
+      t.string :sluggable_string, null: false
+      t.string :content_id_alias
+      t.string :block_type, null: false
+      t.datetime :deleted_at
+      t.string :embed_code
+      t.boolean :testing_artefact, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :block_documents, :content_id, unique: true
+    add_index :block_documents, :sluggable_string, unique: true
+    add_index :block_documents, :content_id_alias, unique: true
+  end
+end

--- a/db/migrate/20260311175427_create_block_editions.rb
+++ b/db/migrate/20260311175427_create_block_editions.rb
@@ -1,0 +1,16 @@
+class CreateBlockEditions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :block_editions do |t|
+      t.references :block_document, null: false, foreign_key: true
+      t.string :type, null: false
+      t.string :title, null: false
+      t.text :description
+      t.text :instructions_to_publishers
+      t.integer :lead_organisation_id
+
+      t.timestamps
+    end
+
+    add_index :block_editions, :type
+  end
+end

--- a/db/migrate/20260311175854_create_block_time_period_date_ranges.rb
+++ b/db/migrate/20260311175854_create_block_time_period_date_ranges.rb
@@ -1,0 +1,11 @@
+class CreateBlockTimePeriodDateRanges < ActiveRecord::Migration[8.1]
+  def change
+    create_table :block_time_period_date_ranges do |t|
+      t.references :edition, null: false, foreign_key: { to_table: :block_editions }
+      t.datetime :start, null: false
+      t.datetime :end, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260325180000_change_lead_organisation_id_to_uuid_in_block_editions.rb
+++ b/db/migrate/20260325180000_change_lead_organisation_id_to_uuid_in_block_editions.rb
@@ -1,0 +1,15 @@
+class ChangeLeadOrganisationIdToUuidInBlockEditions < ActiveRecord::Migration[8.1]
+  def up
+    change_table :block_editions, bulk: true do |t|
+      t.remove :lead_organisation_id, type: :integer
+      t.uuid :lead_organisation_id
+    end
+  end
+
+  def down
+    change_table :block_editions, bulk: true do |t|
+      t.remove :lead_organisation_id, type: :uuid
+      t.integer :lead_organisation_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_11_174532) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_174532) do
     t.datetime "updated_at", null: false
     t.index ["block_document_id"], name: "index_block_editions_on_block_document_id"
     t.index ["type"], name: "index_block_editions_on_type"
+  end
+
+  create_table "block_time_period_date_ranges", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "edition_id", null: false
+    t.datetime "end", null: false
+    t.datetime "start", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_block_time_period_date_ranges_on_edition_id"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -73,82 +82,83 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_174532) do
   end
 
   create_table "edition_authors", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "edition_id", null: false
     t.datetime "created_at", null: false
+    t.integer "edition_id", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
     t.index ["edition_id"], name: "index_edition_authors_on_edition_id"
     t.index ["user_id"], name: "index_edition_authors_on_user_id"
   end
 
   create_table "editions", force: :cascade do |t|
+    t.string "auth_bypass_id"
+    t.text "change_note"
+    t.datetime "created_at", null: false
     t.json "details", null: false
     t.integer "document_id", null: false
-    t.text "state", default: "draft", null: false
-    t.datetime "scheduled_publication"
     t.text "instructions_to_publishers"
-    t.text "title", default: "", null: false
     t.text "internal_change_note"
-    t.text "change_note"
-    t.boolean "major_change"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.uuid "lead_organisation_id"
-    t.string "auth_bypass_id"
+    t.boolean "major_change"
+    t.datetime "scheduled_publication"
+    t.text "state", default: "draft", null: false
+    t.text "title", default: "", null: false
+    t.datetime "updated_at", null: false
     t.datetime "workflow_completed_at", precision: nil
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["title"], name: "index_editions_on_title"
   end
 
   create_table "flipflop_features", force: :cascade do |t|
-    t.text "key", null: false
-    t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
+    t.boolean "enabled", default: false, null: false
+    t.text "key", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipflop_features_on_key"
   end
 
   create_table "outcomes", force: :cascade do |t|
-    t.bigint "edition_id", null: false
-    t.string "type"
-    t.boolean "skipped"
-    t.string "performer"
-    t.bigint "creator_id", null: false
     t.datetime "created_at", null: false
+    t.bigint "creator_id", null: false
+    t.bigint "edition_id", null: false
+    t.string "performer"
+    t.boolean "skipped"
+    t.string "type"
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_outcomes_on_creator_id"
     t.index ["edition_id"], name: "index_outcomes_on_edition_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "name", null: false
-    t.text "uid"
-    t.text "email"
-    t.boolean "disabled", default: false
-    t.boolean "remotely_signed_out", default: false
-    t.text "permissions"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "organisation_slug"
+    t.boolean "disabled", default: false
+    t.text "email"
+    t.text "name", null: false
     t.string "organisation_content_id"
+    t.string "organisation_slug"
+    t.text "permissions"
+    t.boolean "remotely_signed_out", default: false
+    t.text "uid"
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["uid"], name: "index_users_on_uid"
   end
 
   create_table "versions", force: :cascade do |t|
-    t.text "item_type", null: false
-    t.integer "item_id", null: false
-    t.integer "event", null: false
-    t.text "whodunnit"
-    t.text "state"
-    t.json "field_diffs"
     t.datetime "created_at", null: false
+    t.integer "event", null: false
+    t.json "field_diffs"
+    t.integer "item_id", null: false
+    t.text "item_type", null: false
+    t.text "state"
     t.datetime "updated_at", null: false
+    t.text "whodunnit"
     t.index ["item_id"], name: "index_versions_on_item_id"
     t.index ["item_type"], name: "index_versions_on_item_type"
   end
 
   add_foreign_key "block_editions", "block_documents"
+  add_foreign_key "block_time_period_date_ranges", "block_editions", column: "edition_id"
   add_foreign_key "domain_events", "documents"
   add_foreign_key "domain_events", "editions"
   add_foreign_key "domain_events", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,29 +29,42 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_174532) do
     t.index ["sluggable_string"], name: "index_block_documents_on_sluggable_string", unique: true
   end
 
-  create_table "documents", force: :cascade do |t|
-    t.text "block_type"
-    t.text "content_id"
-    t.string "content_id_alias"
+  create_table "block_editions", force: :cascade do |t|
+    t.bigint "block_document_id", null: false
     t.datetime "created_at", null: false
-    t.datetime "deleted_at"
-    t.text "embed_code"
-    t.text "sluggable_string"
-    t.boolean "testing_artefact", default: false, null: false
+    t.text "description"
+    t.text "instructions_to_publishers"
+    t.integer "lead_organisation_id"
+    t.string "title", null: false
+    t.string "type", null: false
     t.datetime "updated_at", null: false
+    t.index ["block_document_id"], name: "index_block_editions_on_block_document_id"
+    t.index ["type"], name: "index_block_editions_on_type"
+  end
+
+  create_table "documents", force: :cascade do |t|
+    t.text "content_id"
+    t.text "sluggable_string"
+    t.text "block_type"
+    t.string "content_id_alias"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "testing_artefact", default: false, null: false
+    t.text "embed_code"
     t.index ["content_id_alias"], name: "index_documents_on_content_id_alias", unique: true
     t.index ["embed_code"], name: "index_documents_on_embed_code", unique: true
   end
 
   create_table "domain_events", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.integer "document_id"
-    t.integer "edition_id"
-    t.jsonb "metadata"
-    t.string "name", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.integer "edition_id"
+    t.integer "document_id"
+    t.string "name", null: false
+    t.jsonb "metadata"
     t.integer "version_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_domain_events_on_document_id"
     t.index ["edition_id"], name: "index_domain_events_on_edition_id"
     t.index ["name"], name: "index_domain_events_on_name"
@@ -60,88 +73,86 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_174532) do
   end
 
   create_table "edition_authors", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.integer "edition_id", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.integer "edition_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["edition_id"], name: "index_edition_authors_on_edition_id"
     t.index ["user_id"], name: "index_edition_authors_on_user_id"
   end
 
   create_table "editions", force: :cascade do |t|
-    t.string "auth_bypass_id"
-    t.text "change_note"
-    t.datetime "created_at", null: false
     t.json "details", null: false
     t.integer "document_id", null: false
-    t.text "instructions_to_publishers"
-    t.text "internal_change_note"
-    t.uuid "lead_organisation_id"
-    t.boolean "major_change"
-    t.datetime "scheduled_publication"
     t.text "state", default: "draft", null: false
+    t.datetime "scheduled_publication"
+    t.text "instructions_to_publishers"
     t.text "title", default: "", null: false
+    t.text "internal_change_note"
+    t.text "change_note"
+    t.boolean "major_change"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "lead_organisation_id"
+    t.string "auth_bypass_id"
     t.datetime "workflow_completed_at", precision: nil
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["title"], name: "index_editions_on_title"
   end
 
   create_table "flipflop_features", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.boolean "enabled", default: false, null: false
     t.text "key", null: false
+    t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipflop_features_on_key"
   end
 
   create_table "outcomes", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "creator_id", null: false
-    t.bigint "domain_event_id"
     t.bigint "edition_id", null: false
-    t.string "performer"
-    t.boolean "skipped"
     t.string "type"
+    t.boolean "skipped"
+    t.string "performer"
+    t.bigint "creator_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_outcomes_on_creator_id"
-    t.index ["domain_event_id"], name: "index_outcomes_on_domain_event_id"
     t.index ["edition_id"], name: "index_outcomes_on_edition_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.boolean "disabled", default: false
-    t.text "email"
     t.text "name", null: false
-    t.string "organisation_content_id"
-    t.string "organisation_slug"
-    t.text "permissions"
-    t.boolean "remotely_signed_out", default: false
     t.text "uid"
+    t.text "email"
+    t.boolean "disabled", default: false
+    t.boolean "remotely_signed_out", default: false
+    t.text "permissions"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "organisation_slug"
+    t.string "organisation_content_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["uid"], name: "index_users_on_uid"
   end
 
   create_table "versions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.integer "event", null: false
-    t.json "field_diffs"
-    t.integer "item_id", null: false
     t.text "item_type", null: false
-    t.text "state"
-    t.datetime "updated_at", null: false
+    t.integer "item_id", null: false
+    t.integer "event", null: false
     t.text "whodunnit"
+    t.text "state"
+    t.json "field_diffs"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_versions_on_item_id"
     t.index ["item_type"], name: "index_versions_on_item_type"
   end
 
+  add_foreign_key "block_editions", "block_documents"
   add_foreign_key "domain_events", "documents"
   add_foreign_key "domain_events", "editions"
   add_foreign_key "domain_events", "users"
   add_foreign_key "domain_events", "versions"
-  add_foreign_key "outcomes", "domain_events"
   add_foreign_key "outcomes", "editions"
   add_foreign_key "outcomes", "users", column: "creator_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
     t.datetime "created_at", null: false
     t.text "description"
     t.text "instructions_to_publishers"
-    t.integer "lead_organisation_id"
+    t.uuid "lead_organisation_id"
     t.string "title", null: false
     t.string "type", null: false
     t.datetime "updated_at", null: false
@@ -52,28 +52,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
   end
 
   create_table "documents", force: :cascade do |t|
-    t.text "content_id"
-    t.text "sluggable_string"
     t.text "block_type"
+    t.text "content_id"
     t.string "content_id_alias"
-    t.datetime "deleted_at"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "testing_artefact", default: false, null: false
+    t.datetime "deleted_at"
     t.text "embed_code"
+    t.text "sluggable_string"
+    t.boolean "testing_artefact", default: false, null: false
+    t.datetime "updated_at", null: false
     t.index ["content_id_alias"], name: "index_documents_on_content_id_alias", unique: true
     t.index ["embed_code"], name: "index_documents_on_embed_code", unique: true
   end
 
   create_table "domain_events", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "edition_id"
-    t.integer "document_id"
-    t.string "name", null: false
-    t.jsonb "metadata"
-    t.integer "version_id"
     t.datetime "created_at", null: false
+    t.integer "document_id"
+    t.integer "edition_id"
+    t.jsonb "metadata"
+    t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "version_id"
     t.index ["document_id"], name: "index_domain_events_on_document_id"
     t.index ["edition_id"], name: "index_domain_events_on_edition_id"
     t.index ["name"], name: "index_domain_events_on_name"
@@ -109,6 +109,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
     t.index ["title"], name: "index_editions_on_title"
   end
 
+  create_table "events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "document_id"
+    t.integer "edition_id"
+    t.jsonb "metadata"
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "version_id"
+    t.index ["document_id"], name: "index_events_on_document_id"
+    t.index ["edition_id"], name: "index_events_on_edition_id"
+    t.index ["name"], name: "index_events_on_name"
+    t.index ["user_id"], name: "index_events_on_user_id"
+    t.index ["version_id"], name: "index_events_on_version_id"
+  end
+
   create_table "flipflop_features", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "enabled", default: false, null: false
@@ -120,12 +136,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
   create_table "outcomes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "creator_id", null: false
+    t.bigint "domain_event_id"
     t.bigint "edition_id", null: false
     t.string "performer"
     t.boolean "skipped"
     t.string "type"
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_outcomes_on_creator_id"
+    t.index ["domain_event_id"], name: "index_outcomes_on_domain_event_id"
     t.index ["edition_id"], name: "index_outcomes_on_edition_id"
   end
 
@@ -163,6 +181,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_175854) do
   add_foreign_key "domain_events", "editions"
   add_foreign_key "domain_events", "users"
   add_foreign_key "domain_events", "versions"
+  add_foreign_key "outcomes", "domain_events"
   add_foreign_key "outcomes", "editions"
   add_foreign_key "outcomes", "users", column: "creator_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_16_134808) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_11_174532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "block_documents", force: :cascade do |t|
+    t.string "block_type", null: false
+    t.uuid "content_id", null: false
+    t.string "content_id_alias"
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at"
+    t.string "embed_code"
+    t.string "sluggable_string", null: false
+    t.boolean "testing_artefact", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id"], name: "index_block_documents_on_content_id", unique: true
+    t.index ["content_id_alias"], name: "index_block_documents_on_content_id_alias", unique: true
+    t.index ["sluggable_string"], name: "index_block_documents_on_sluggable_string", unique: true
+  end
 
   create_table "documents", force: :cascade do |t|
     t.text "block_type"

--- a/docs/architecture/decisions/0011-experiment-with-traditional-activerecord-models.md
+++ b/docs/architecture/decisions/0011-experiment-with-traditional-activerecord-models.md
@@ -1,0 +1,265 @@
+# 11. Experiment with Traditional ActiveRecord Models for Content Blocks
+
+Date: 2026-03-11
+
+Status: Experimental
+
+## Context
+
+### Current State
+
+The Content Block Manager currently uses a **schema-driven generic approach** for modeling content blocks:
+
+1. **Single Document Model:** All block types use a single `Document` model (no subclasses).
+2. **Single Edition Model:** All block types use a single `Edition` model with a generic `details` JSON column.
+3. **JSON Schema Validation:** Block type structure is defined and validated via JSON schemas stored in `app/models/schema/definitions/*.json`.
+4. **Generic Forms:** Form interfaces are dynamically generated from the JSON schemas.
+
+This architecture provides flexibility and allows new block types to be added by defining a JSON schema without creating new models or migrations.
+
+This was a necessary technical design initially as all schemas were defined in Publishing API. However, in order to have greater control, particularly over validation, we've recently moved the schema into this repository (See [ADR 10 Make Content Block Manager the source of truth for schemas][])
+
+The use of JSON schema definition is no longer a requirement.
+
+### The Question
+
+As the application grows, we're evaluating whether the schema-driven approach provides the best developer experience and maintainability, or whether a **traditional Rails ActiveRecord approach** with dedicated models and tables might be clearer and easier to work with.
+
+Specifically, we want to understand:
+
+2. **Developer Experience:** Is it easier and faster to work with explicit Rails models and associations vs. generic JSON columns? Our experience when adding a new block type is that there are numerous differences or additional features which are needed. At face value they appear minor but in reality prove complex to introduce to an application model which is entirely generic. Our small number of classes can do everything, but at what price in terms of complexity and cognitive load.
+3. **Maintainability:** Are dedicated models with typed columns easier to understand and modify than schema definitions?
+4. **Adding Fields:** Is it simpler to add a migration for a new column vs. updating a JSON schema?
+5. **Performance:** Do typed columns with proper indexes perform better than querying within JSON?
+6. **Testing:** Are traditional model tests more straightforward than testing schema validation?
+
+## Decision
+
+We will conduct an **experiment** by implementing an alternative architecture using traditional ActiveRecord models, running **in parallel** with the existing schema-driven system.
+
+### Experiment Scope
+
+We will implement the **TimePeriod** block type as a proof-of-concept using the new architecture. This will allow us to:
+
+- Compare both approaches side-by-side in the same codebase
+- Evaluate real-world developer experience
+- Make an informed decision about which direction to pursue
+
+This is **not yet** a decision to migrate away from the existing schema-based paradigm - it is purely exploratory.
+
+## Architecture
+
+### Namespace
+
+All experimental code will live in the `Block::` namespace to run parallel with the existing system:
+
+- Existing: `Document`, `Edition`
+- Experimental: `Block::Document`, `Block::Edition`, `Block::TimePeriodEdition`, etc.
+
+### Key Architectural Choices
+
+#### 1. Document Model (No STI)
+
+`Block::Document` is a **single concrete class** (no Single Table Inheritance):
+
+- Has a `block_type` string column to track which edition type it uses ("time_period", "tax", etc.)
+- Does not subclass (no `Block::TimePeriodDocument`, etc.)
+- Rationale: Documents are generic containers; the specificity lives in editions
+
+#### 2. Edition Model (STI)
+
+`Block::Edition` uses **Single Table Inheritance**:
+
+- Base class: `Block::Edition` (abstract - cannot instantiate directly)
+- Subclasses: `Block::TimePeriodEdition`, `Block::TaxEdition`, etc.
+- `block_editions.type` column stores the subclass name
+- Rationale: Different block types have different fields and behavior
+
+#### 3. Content in Specialized Tables
+
+Each edition type has its own dedicated content tables with typed columns:
+
+- Example: `Block::TimePeriodEdition` has_one `Block::TimePeriodDateRange`
+- Content table: `block_time_period_date_ranges` with `start` and `end` datetime columns
+- Rationale: Explicit schema, database-level validation, proper indexing
+
+#### 4. No Generic Details Column
+
+Instead of a `details` JSON column:
+
+- Each edition subclass implements a `#details` method that serializes from its associated content models
+- Example: `TimePeriodEdition#details` composes from `description` + `date_range.to_details`
+- Rationale: One-way serialization for API consumption; editing happens via associations
+
+
+#### 6. Two-Controller Pattern for Multi-Step Forms
+
+Rather than use general-purpose multi-step "wizard" code (`Workflow`), it may be preferable, especially in the case of simple blocks (e.g. `TimePeriod`) to use separate controllers for different form steps:
+
+- `TimePeriodEditionsController` - Step 1: common fields (title, description, organisation)
+- `TimePeriodDateRangesController` - Step 2: type-specific fields (start/end dates)
+
+#### 7. Reuse of Existing Concerns
+
+Where possible, this experiment will aim to reuse existing behaviour which is packaged up in modules, e.g.:
+
+- `Block::Edition` includes `::Edition::HasLeadOrganisation` for organisation validation
+- `Block::TimePeriodDateRange` includes `DateValidation` for handling invalid multiparameter dates
+
+#### 8. Shared Fields on Base Table
+
+Fields common to all block types live on `block_editions`:
+
+- `description` - all block types have this
+- `title` - all block types have this
+- `instructions_to_publishers` - all block types have this
+- Rationale: Avoids duplication in type-specific tables
+
+## Implementation Notes
+
+### Complexities to explore
+
+#### Date multiparameter assignment
+
+It will be interesting to explore whether validation of a `TimePeriod#date_range`'s `start` and `end` is significantly simpler using this active record approach.
+
+Rails date fields submit as multiparameter attributes (e.g., `start(1i)`, `start(2i)` etc). Perhaps use of the existing `DateValidation` behaviour will do whats's needed?
+
+## Implementation Plan
+
+### Database Schema
+
+```
+block_documents
+  - id
+  - content_id (uuid, unique, indexed)
+  - sluggable_string (unique, indexed)
+  - content_id_alias (unique, indexed) -- generated via FriendlyId from sluggable_string
+  - block_type (string: "time_period", "tax", etc.)
+  - embed_code -- uses content_id_alias, e.g., {{embed:content_block_time_period:current-tax-year}}
+  - deleted_at
+  - timestamps
+
+block_editions (STI)
+  - id
+  - block_document_id (FK to block_documents)
+  - type (STI discriminator)
+  - title
+  - description
+  - instructions_to_publishers
+  - lead_organisation_id (uuid) -- FK to organisations
+  - timestamps
+
+block_time_period_date_ranges
+  - id
+  - edition_id (FK to block_editions, unique index)
+  - start (datetime)
+  - end (datetime)
+  - timestamps
+```
+
+### Model Structure
+
+```ruby
+Block::Document
+  extend FriendlyId
+  friendly_id :sluggable_string, use: :slugged, slug_column: :content_id_alias
+
+  has_many :editions, class_name: "Block::Edition"
+
+  def built_embed_code
+    "{{embed:content_block_#{block_type}:#{content_id_alias}}}"
+  end
+
+Block::Edition (abstract STI base)
+  include ::Edition::HasLeadOrganisation  # reuses existing concern
+
+  belongs_to :document, class_name: "Block::Document"
+
+  def details
+    raise NotImplementedError
+  end
+
+Block::TimePeriodEdition < Block::Edition
+  has_one :date_range, class_name: "Block::TimePeriodDateRange"
+
+  def details
+    {
+      "description" => description,
+      "date_range" => date_range.to_details
+    }
+  end
+
+Block::TimePeriodDateRange
+  include DateValidation  # reuses existing concern for invalid date handling
+
+  belongs_to :edition, class_name: "Block::TimePeriodEdition"
+
+  def to_details
+    {
+      "start" => { "date" => ..., "time" => ... },
+      "end" => { "date" => ..., "time" => ... }
+    }
+  end
+```
+
+### Controller Structure (Two-Controller Pattern)
+
+```ruby
+Block::TimePeriodEditionsController
+  # Step 1: Common fields (title, description, organisation)
+  def create
+    @edition = Block::TimePeriodEdition.new(edition_params)
+    @edition.build_document(block_type: "time_period")
+
+    if @edition.save
+      redirect_to edit_block_document_time_period_date_range_path(...)
+    else
+      render :new
+    end
+  end
+
+Block::TimePeriodDateRangesController
+  # Step 2: Type-specific fields (start/end dates)
+  def update
+    if @edition.update(edition_params)
+      redirect_to block_time_period_edition_path(@edition)
+    else
+      render :edit
+    end
+  end
+```
+
+## Consequences
+
+### Benefits of the Experimental Approach
+
+We believe that this approach may be significantly easier (faster) to develop:
+
+- fixing bugs
+- adding features
+- adding new block types
+
+Once the service goes into maintenance mode, simplicity will be a major factor in its long term success. If it's hard to maintain and develop, it's likely to be perceived as risky and expensive.
+
+### Drawbacks of the Experimental Approach
+
+1. **More Code:** Requires models, migrations, and factories for each block type
+2. **Schema Changes:** Adding fields requires migrations instead of JSON updates
+3. **Less Flexibility:** Structure is more rigid (though this might be a good thing)
+4. **Parallel Maintenance:** During the experiment, we maintain two systems
+
+### Evaluation Criteria
+
+After implementing the TimePeriod block with the new architecture, we will evaluate:
+
+1. **Code Clarity:** Is it easier to understand what fields exist and how they relate?
+2. **Development Speed:** How quickly can we add new fields or modify existing ones?
+3. **Testing Experience:** Are tests easier to write and more reliable?
+4. **Team Preference:** Which approach do developers prefer working with?
+
+## Status
+
+This ADR has **Experimental** status and will be updated to **Accepted** or **Rejected** after the experiment concludes.
+
+[ADR 10 Make Content Block Manager the source of truth for schemas]: ./0010-make-content-block-manager-the-source-of-truth-for-schemas.md

--- a/features/block/time_period/create_block.feature
+++ b/features/block/time_period/create_block.feature
@@ -18,3 +18,10 @@ Feature: Create "Time period" content block (Block architecture)
   Scenario: Editor must supply valid edition details
     When I submit the new-style time period form incorrectly
     Then I see the errors messages describing the problems with the new-style edition
+
+  Scenario: Editor must supply valid date range dates
+    When I fill the new-style time period form correctly
+    And I proceed to add a date range for the new-style Time period
+    And I supply an invalid date for the date range
+    And I save and continue
+    Then I see the error message for the invalid date

--- a/features/block/time_period/create_block.feature
+++ b/features/block/time_period/create_block.feature
@@ -1,0 +1,17 @@
+@wip
+Feature: Create "Time period" content block (Block architecture)
+  - So that I can publish a block representing a time period
+  - As an editor
+  - I want to draft the initial block (and edit that draft)
+
+  Background:
+    Given I am logged in
+    And the organisation "Ministry of Example" exists
+    And I am on the new-style time period form
+
+  Scenario: Editor can create a "Time period" content block
+    When I fill the new-style time period form correctly
+    And I proceed to add a date range for the new-style Time period
+    And I supply the initial new-style time periods correctly
+    And I save and continue
+    Then I see the initial new-style time period represented clearly

--- a/features/block/time_period/create_block.feature
+++ b/features/block/time_period/create_block.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Create "Time period" content block (Block architecture)
   - So that I can publish a block representing a time period
   - As an editor
@@ -15,3 +14,7 @@ Feature: Create "Time period" content block (Block architecture)
     And I supply the initial new-style time periods correctly
     And I save and continue
     Then I see the initial new-style time period represented clearly
+
+  Scenario: Editor must supply valid edition details
+    When I submit the new-style time period form incorrectly
+    Then I see the errors messages describing the problems with the new-style edition

--- a/features/step_definitions/block/time_period_steps.rb
+++ b/features/step_definitions/block/time_period_steps.rb
@@ -1,0 +1,61 @@
+Given("I am on the new-style time period form") do
+  visit new_block_time_period_edition_path
+end
+
+When("I fill the new-style time period form correctly") do
+  fill_in "Title", with: "Current Tax Year"
+  fill_in "Description", with: "A time period representing the current tax year"
+  select "Ministry of Example", from: "edition_lead_organisation_id"
+  fill_in "Instructions to publishers", with: "Use this for current tax year content"
+end
+
+When("I submit the new-style time period form incorrectly") do
+  # no-op
+  click_button "Save and continue"
+end
+
+Then("I see the errors messages describing the problems with the new-style edition") do
+  expect(page).to have_content("Title cannot be blank")
+  expect(page).to have_content("Lead organisation cannot be blank")
+end
+
+When("I proceed to add a date range for the new-style Time period") do
+  click_button "Save and continue"
+  @edition = Block::TimePeriodEdition.last
+end
+
+When("I supply the initial new-style time periods correctly") do
+  # Start date
+  fill_in "edition[date_range_attributes][start(3i)]", with: "6"
+  fill_in "edition[date_range_attributes][start(2i)]", with: "4"
+  fill_in "edition[date_range_attributes][start(1i)]", with: "2025"
+  select "09", from: "start_hour"
+  select "00", from: "start_minute"
+
+  # End date
+  fill_in "edition[date_range_attributes][end(3i)]", with: "5"
+  fill_in "edition[date_range_attributes][end(2i)]", with: "4"
+  fill_in "edition[date_range_attributes][end(1i)]", with: "2026"
+  select "17", from: "end_hour"
+  select "30", from: "end_minute"
+end
+
+Then("I see the initial new-style time period represented clearly") do
+  edition = @edition.reload
+
+  expect(page).to have_content(edition.title)
+  expect(page).to have_content(edition.description)
+  expect(page).to have_content(edition.instructions_to_publishers)
+  expect(page).to have_content(edition.document.embed_code)
+
+  expect(page).to have_content(
+    ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+      edition.date_range.start.to_s,
+    ).render,
+  )
+  expect(page).to have_content(
+    ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+      edition.date_range.end.to_s,
+    ).render,
+  )
+end

--- a/features/step_definitions/block/time_period_steps.rb
+++ b/features/step_definitions/block/time_period_steps.rb
@@ -59,3 +59,23 @@ Then("I see the initial new-style time period represented clearly") do
     ).render,
   )
 end
+
+When("I supply an invalid date for the date range") do
+  # Start date with invalid month (23)
+  fill_in "edition[date_range_attributes][start(3i)]", with: "6"
+  fill_in "edition[date_range_attributes][start(2i)]", with: "23"
+  fill_in "edition[date_range_attributes][start(1i)]", with: "2025"
+  select "09", from: "start_hour"
+  select "00", from: "start_minute"
+
+  # Valid end date
+  fill_in "edition[date_range_attributes][end(3i)]", with: "5"
+  fill_in "edition[date_range_attributes][end(2i)]", with: "4"
+  fill_in "edition[date_range_attributes][end(1i)]", with: "2026"
+  select "17", from: "end_hour"
+  select "30", from: "end_minute"
+end
+
+Then("I see the error message for the invalid date") do
+  expect(page).to have_content("Start date is not a valid date")
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
 [
-  Dir[Rails.root.join("spec/factories/*.rb")],
+  Dir[Rails.root.join("spec/factories/**/*.rb")],
   Dir[Rails.root.join("engines/**/spec/factories/*.rb")],
 ].flatten.sort.each { |f| require f }

--- a/spec/factories/block/documents.rb
+++ b/spec/factories/block/documents.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :block_document, class: "Block::Document" do
+    sequence(:sluggable_string) { |n| "block-document-#{n}" }
+    block_type { "time_period" }
+    testing_artefact { false }
+
+    trait :with_time_period_edition do
+      after(:create) do |document|
+        create(:block_time_period_edition, block_document: document)
+      end
+    end
+  end
+end

--- a/spec/factories/block/other_editions.rb
+++ b/spec/factories/block/other_editions.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :other_edition, class: "Block::OtherEdition" do
     association :document, factory: :block_document
     title { "Test Other Edition" }
+    lead_organisation_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/block/other_editions.rb
+++ b/spec/factories/block/other_editions.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :other_edition, class: "Block::OtherEdition" do
+    association :document, factory: :block_document
+    title { "Test Other Edition" }
+  end
+end

--- a/spec/factories/block/time_period_date_ranges.rb
+++ b/spec/factories/block/time_period_date_ranges.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :block_time_period_date_range, class: "Block::TimePeriodDateRange" do
-    association :edition, factory: :block_time_period_edition
+    association :edition, factory: :time_period_edition
     start { Time.zone.parse("2025-04-06 00:00") }
     self.end { Time.zone.parse("2026-04-05 23:59") }
   end

--- a/spec/factories/block/time_period_date_ranges.rb
+++ b/spec/factories/block/time_period_date_ranges.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :block_time_period_date_range, class: "Block::TimePeriodDateRange" do
+    association :edition, factory: :block_time_period_edition
+    start { Time.zone.parse("2025-04-06 00:00") }
+    self.end { Time.zone.parse("2026-04-05 23:59") }
+  end
+end

--- a/spec/factories/block/time_period_editions.rb
+++ b/spec/factories/block/time_period_editions.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     association :document, factory: :block_document, block_type: "time_period"
     sequence(:title) { |n| "Time Period #{n}" }
     description { "A time period description" }
+    lead_organisation_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/block/time_period_editions.rb
+++ b/spec/factories/block/time_period_editions.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :block_time_period_edition, class: "Block::TimePeriodEdition" do
+  factory :time_period_edition, class: "Block::TimePeriodEdition" do
     association :document, factory: :block_document, block_type: "time_period"
     sequence(:title) { |n| "Time Period #{n}" }
     description { "A time period description" }

--- a/spec/factories/block/time_period_editions.rb
+++ b/spec/factories/block/time_period_editions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :block_time_period_edition, class: "Block::TimePeriodEdition" do
+    association :document, factory: :block_document, block_type: "time_period"
+    sequence(:title) { |n| "Time Period #{n}" }
+    description { "A time period description" }
+  end
+end

--- a/spec/requests/block/documents_spec.rb
+++ b/spec/requests/block/documents_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "Block::Documents", type: :request do
+  setup do
+    logout
+    user = create(:user)
+    login_as(user)
+  end
+
+  let(:organisation) { build(:organisation, name: "Test Org") }
+
+  before do
+    allow(Organisation).to receive(:all).and_return([organisation])
+    allow(Organisation).to receive(:find).and_return(organisation)
+  end
+
+  describe "GET /block/documents" do
+    it "returns a successful response" do
+      get block_documents_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "assigns editions from all documents" do
+      document1 = create(:block_document, block_type: "time_period")
+      document2 = create(:block_document, block_type: "time_period")
+      edition1 = create(:time_period_edition, document: document1)
+      edition2 = create(:time_period_edition, document: document2)
+
+      get block_documents_path
+
+      expect(response.body).to include(edition1.title)
+      expect(response.body).to include(edition2.title)
+    end
+  end
+end

--- a/spec/requests/block/time_period_date_ranges_spec.rb
+++ b/spec/requests/block/time_period_date_ranges_spec.rb
@@ -1,0 +1,121 @@
+RSpec.describe "Block::TimePeriodDateRanges", type: :request do
+  setup do
+    logout
+    user = create(:user)
+    login_as(user)
+  end
+
+  describe "GET /block/documents/:document_id/time-period-date-ranges/:id" do
+    let(:edition) { create(:time_period_edition) }
+    let(:document) { edition.document }
+
+    it "returns http success" do
+      get block_document_time_period_date_range_path(document, edition)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns the requested edition" do
+      get block_document_time_period_date_range_path(document, edition)
+      expect(assigns(:edition)).to eq(edition)
+    end
+
+    it "assigns the document" do
+      get block_document_time_period_date_range_path(document, edition)
+      expect(assigns(:document)).to eq(document)
+    end
+  end
+
+  describe "GET /block/documents/:document_id/time-period-date-ranges/:id/edit" do
+    let(:edition) { create(:time_period_edition) }
+    let(:document) { edition.document }
+
+    it "returns http success" do
+      get edit_block_document_time_period_date_range_path(document, edition)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns the requested edition" do
+      get edit_block_document_time_period_date_range_path(document, edition)
+      expect(assigns(:edition)).to eq(edition)
+    end
+  end
+
+  describe "PATCH /block/documents/:document_id/time-period-date-ranges/:id" do
+    let(:edition) do
+      create(:time_period_edition, title: "Old Title", description: "Old")
+    end
+    let(:document) { edition.document }
+
+    let(:valid_date_range_attributes) do
+      {
+        edition: {
+          date_range_attributes: {
+            start: "2025-04-06 09:00",
+            end: "2026-04-05 17:30",
+          },
+        },
+      }
+    end
+
+    let(:invalid_date_range_attributes) do
+      {
+        edition: {
+          date_range_attributes: {
+            start: "2026-04-06 09:00",
+            end: "2025-04-05 17:30", # End before start
+          },
+        },
+      }
+    end
+
+    context "with valid parameters" do
+      it "updates the date range" do
+        patch block_document_time_period_date_range_path(document, edition),
+              params: valid_date_range_attributes
+        edition.reload
+        expect(edition.date_range.start).to eq(
+          Time.zone.parse("2025-04-06 09:00"),
+        )
+        expect(edition.date_range.end).to eq(
+          Time.zone.parse("2026-04-05 17:30"),
+        )
+      end
+
+      it "redirects to the edition" do
+        patch block_document_time_period_date_range_path(document, edition),
+              params: valid_date_range_attributes
+        expect(response).to redirect_to(
+          block_document_time_period_date_range_path(document, edition),
+        )
+      end
+
+      it "sets a notice flash message" do
+        patch block_document_time_period_date_range_path(document, edition),
+              params: valid_date_range_attributes
+        expect(flash[:notice]).to eq("Time period was successfully updated.")
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not update the edition" do
+        original_start = edition.date_range&.start
+        patch block_document_time_period_date_range_path(document, edition),
+              params: invalid_date_range_attributes
+        edition.reload
+        expect(edition.date_range&.start).to eq(original_start)
+      end
+
+      it "returns unprocessable entity status" do
+        patch block_document_time_period_date_range_path(document, edition),
+              params: invalid_date_range_attributes
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the edit template" do
+        patch block_document_time_period_date_range_path(document, edition),
+              params: invalid_date_range_attributes
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/requests/block/time_period_date_ranges_spec.rb
+++ b/spec/requests/block/time_period_date_ranges_spec.rb
@@ -85,14 +85,8 @@ RSpec.describe "Block::TimePeriodDateRanges", type: :request do
         patch block_document_time_period_date_range_path(document, edition),
               params: valid_date_range_attributes
         expect(response).to redirect_to(
-          block_document_time_period_date_range_path(document, edition),
+          block_time_period_edition_path(edition),
         )
-      end
-
-      it "sets a notice flash message" do
-        patch block_document_time_period_date_range_path(document, edition),
-              params: valid_date_range_attributes
-        expect(flash[:notice]).to eq("Time period was successfully updated.")
       end
     end
 

--- a/spec/requests/block/time_period_editions_spec.rb
+++ b/spec/requests/block/time_period_editions_spec.rb
@@ -67,12 +67,15 @@ RSpec.describe "Block::TimePeriodEditions", type: :request do
         expect(edition.document.sluggable_string).to eq("Tax Year 2025/26")
       end
 
-      it "redirects to the created edition" do
+      it "redirects to the date range form" do
         post block_time_period_editions_path,
              params: valid_attributes
         edition = Block::TimePeriodEdition.last
         expect(response).to redirect_to(
-          block_time_period_edition_path(edition),
+          edit_block_document_time_period_date_range_path(
+            edition.document,
+            edition,
+          ),
         )
       end
     end

--- a/spec/requests/block/time_period_editions_spec.rb
+++ b/spec/requests/block/time_period_editions_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe "Block::TimePeriodEditions", type: :request do
+  setup do
+    logout
+    user = create(:user)
+    login_as(user)
+  end
+
+  let(:organisation) { build(:organisation, name: "Test Org") }
+
+  before do
+    allow(Organisation).to receive(:all).and_return([organisation])
+  end
+
+  describe "GET /block/time_period_editions/new" do
+    it "returns http success" do
+      get new_block_time_period_edition_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns a new edition with a new document" do
+      get new_block_time_period_edition_path
+      expect(assigns(:edition)).to be_a_new(Block::TimePeriodEdition)
+      expect(assigns(:edition).document).to be_a_new(Block::Document)
+      expect(assigns(:edition).document.block_type).to eq("time_period")
+    end
+  end
+
+  describe "POST /block/time_period_editions" do
+    let(:valid_attributes) do
+      {
+        edition: {
+          title: "Tax Year 2025/26",
+          description: "Current tax year",
+          instructions_to_publishers: "Use this for tax year content",
+          lead_organisation_id: organisation.id,
+        },
+      }
+    end
+
+    let(:invalid_attributes) do
+      {
+        edition: {
+          title: "",
+        },
+      }
+    end
+
+    context "with valid parameters" do
+      it "creates a new Block::TimePeriodEdition" do
+        expect {
+          post block_time_period_editions_path,
+               params: valid_attributes
+        }.to change(Block::TimePeriodEdition, :count).by(1)
+      end
+
+      it "creates a new Block::Document" do
+        expect {
+          post block_time_period_editions_path,
+               params: valid_attributes
+        }.to change(Block::Document, :count).by(1)
+      end
+
+      it "sets the document's sluggable_string from the title" do
+        post block_time_period_editions_path,
+             params: valid_attributes
+        edition = Block::TimePeriodEdition.last
+        expect(edition.document.sluggable_string).to eq("Tax Year 2025/26")
+      end
+
+      it "redirects to the created edition" do
+        post block_time_period_editions_path,
+             params: valid_attributes
+        edition = Block::TimePeriodEdition.last
+        expect(response).to redirect_to(
+          block_time_period_edition_path(edition),
+        )
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a new Block::TimePeriodEdition" do
+        expect {
+          post block_time_period_editions_path,
+               params: invalid_attributes
+        }.not_to change(Block::TimePeriodEdition, :count)
+      end
+
+      it "returns unprocessable entity status" do
+        post block_time_period_editions_path,
+             params: invalid_attributes
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the new template" do
+        post block_time_period_editions_path,
+             params: invalid_attributes
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "GET /block/time_period_editions/:id" do
+    let(:organisation) { build(:organisation) }
+    let(:edition) { create(:time_period_edition, title: "Test Edition", lead_organisation_id: organisation.id) }
+
+    it "returns http success" do
+      get block_time_period_edition_path(edition)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns the requested edition" do
+      get block_time_period_edition_path(edition)
+      expect(assigns(:edition)).to eq(edition)
+    end
+  end
+end

--- a/spec/routing/block/time_period_date_ranges_routing_spec.rb
+++ b/spec/routing/block/time_period_date_ranges_routing_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe "Block::TimePeriodDateRanges routing", type: :routing do
+  describe "routes to Block::TimePeriodDateRangesController" do
+    it "routes GET /block/documents/:document_id/time-period-date-ranges/:id to #show" do
+      expect(get: "/block/documents/456/time-period-date-ranges/123").to route_to(
+        controller: "block/time_period_date_ranges",
+        action: "show",
+        document_id: "456",
+        id: "123",
+      )
+    end
+
+    it "routes GET /block/documents/:document_id/time-period-date-ranges/:id/edit to #edit" do
+      expect(get: "/block/documents/456/time-period-date-ranges/123/edit").to route_to(
+        controller: "block/time_period_date_ranges",
+        action: "edit",
+        document_id: "456",
+        id: "123",
+      )
+    end
+
+    it "routes PATCH /block/documents/:document_id/time-period-date-ranges/:id to #update" do
+      expect(patch: "/block/documents/456/time-period-date-ranges/123").to route_to(
+        controller: "block/time_period_date_ranges",
+        action: "update",
+        document_id: "456",
+        id: "123",
+      )
+    end
+
+    it "routes PUT /block/documents/:document_id/time-period-date-ranges/:id to #update" do
+      expect(put: "/block/documents/456/time-period-date-ranges/123").to route_to(
+        controller: "block/time_period_date_ranges",
+        action: "update",
+        document_id: "456",
+        id: "123",
+      )
+    end
+  end
+
+  describe "named route helpers" do
+    it "generates block_document_time_period_date_range_path with ids" do
+      expect(block_document_time_period_date_range_path(456, 123)).to eq(
+        "/block/documents/456/time-period-date-ranges/123",
+      )
+    end
+
+    it "generates edit_block_document_time_period_date_range_path with ids" do
+      expect(edit_block_document_time_period_date_range_path(456, 123)).to eq(
+        "/block/documents/456/time-period-date-ranges/123/edit",
+      )
+    end
+  end
+end

--- a/spec/routing/block/time_period_editions_spec.rb
+++ b/spec/routing/block/time_period_editions_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+RSpec.describe "Block::TimePeriodEditions routing", type: :routing do
+  describe "routes to Block::TimePeriodEditionsController" do
+    it "routes GET /block/time_period_editions/new to #new" do
+      expect(get: "/block/time_period_editions/new").to route_to(
+        controller: "block/time_period_editions",
+        action: "new",
+      )
+    end
+
+    it "routes POST /block/time_period_editions to #create" do
+      expect(post: "/block/time_period_editions").to route_to(
+        controller: "block/time_period_editions",
+        action: "create",
+      )
+    end
+
+    it "routes GET /block/time_period_editions/:id to #show" do
+      expect(get: "/block/time_period_editions/1").to route_to(
+        controller: "block/time_period_editions",
+        action: "show",
+        id: "1",
+      )
+    end
+
+    it "routes GET /block/time_period_editions/:id/edit to #edit" do
+      expect(get: "/block/time_period_editions/1/edit").to route_to(
+        controller: "block/time_period_editions",
+        action: "edit",
+        id: "1",
+      )
+    end
+
+    it "routes PATCH /block/time_period_editions/:id to #update" do
+      expect(patch: "/block/time_period_editions/1").to route_to(
+        controller: "block/time_period_editions",
+        action: "update",
+        id: "1",
+      )
+    end
+
+    it "routes PUT /block/time_period_editions/:id to #update" do
+      expect(put: "/block/time_period_editions/1").to route_to(
+        controller: "block/time_period_editions",
+        action: "update",
+        id: "1",
+      )
+    end
+  end
+
+  describe "named route helpers" do
+    it "generates new_block_time_period_edition_path" do
+      expect(new_block_time_period_edition_path).to eq("/block/time_period_editions/new")
+    end
+
+    it "generates block_time_period_editions_path" do
+      expect(block_time_period_editions_path).to eq("/block/time_period_editions")
+    end
+
+    it "generates block_time_period_edition_path with id" do
+      expect(block_time_period_edition_path(1)).to eq("/block/time_period_editions/1")
+    end
+
+    it "generates edit_block_time_period_edition_path with id" do
+      expect(edit_block_time_period_edition_path(1)).to eq("/block/time_period_editions/1/edit")
+    end
+  end
+end

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -1,4 +1,27 @@
 RSpec.describe Block::Document, type: :model do
+  describe "associations" do
+    describe "#time_period_editions" do
+      it "builds a TimePeriodEdition with the correct type" do
+        document = build(:block_document, block_type: "time_period")
+        edition = document.time_period_editions.build(title: "Test")
+
+        expect(edition).to be_a(Block::TimePeriodEdition)
+        expect(edition.type).to eq("Block::TimePeriodEdition")
+      end
+
+      it "only returns TimePeriodEdition instances" do
+        document = create(:block_document, block_type: "time_period")
+        time_period = create(:time_period_edition, document: document)
+        other = create(:other_edition, document: document)
+
+        expect(document.editions.count).to eq(2)
+        expect(document.time_period_editions.count).to eq(1)
+        expect(document.time_period_editions.first).to eq(time_period)
+        expect(document.time_period_editions).not_to include(other)
+      end
+    end
+  end
+
   describe "callbacks" do
     describe "generate_content_id" do
       it "generates a UUID for content_id before validation on create" do

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe Block::Document, type: :model do
+  describe "callbacks" do
+    describe "generate_content_id" do
+      it "generates a UUID for content_id before validation on create" do
+        document = described_class.new(
+          sluggable_string: "test-block",
+          block_type: "time_period",
+        )
+        expect(document.content_id).to be_nil
+        document.valid?
+        expect(document.content_id).to be_present
+        uuid_pattern = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/
+        expect(document.content_id)
+          .to match(/#{uuid_pattern}[0-9a-f]{4}-[0-9a-f]{12}\z/)
+      end
+
+      it "does not override an existing content_id" do
+        custom_uuid = SecureRandom.uuid
+        document = described_class.new(
+          content_id: custom_uuid,
+          sluggable_string: "test-block",
+          block_type: "time_period",
+        )
+        document.valid?
+        expect(document.content_id).to eq(custom_uuid)
+      end
+    end
+
+    describe "generate_embed_code" do
+      it "generates embed_code after validation on create using content_id_alias" do
+        document = described_class.new(
+          sluggable_string: "test-block",
+          block_type: "time_period",
+        )
+        expect(document.embed_code).to be_nil
+        document.valid?
+        expect(document.embed_code).to be_present
+        expect(document.embed_code).to eq("{{embed:content_block_time_period:test-block}}")
+      end
+    end
+  end
+
+  describe "#built_embed_code" do
+    it "returns the embed code format using content_id_alias" do
+      document = described_class.new(
+        sluggable_string: "current-tax-year",
+        block_type: "time_period",
+      )
+      document.valid? # triggers FriendlyId to set content_id_alias
+      expect(document.built_embed_code).to eq("{{embed:content_block_time_period:current-tax-year}}")
+    end
+  end
+
+  describe "#embed_code_for_field" do
+    it "returns the embed code format for a specific field using content_id_alias" do
+      document = described_class.new(
+        sluggable_string: "current-tax-year",
+        block_type: "time_period",
+      )
+      document.valid? # triggers FriendlyId to set content_id_alias
+      expect(document.embed_code_for_field("date_range/start/date"))
+        .to eq("{{embed:content_block_time_period:current-tax-year/date_range/start/date}}")
+    end
+  end
+
+  describe "#title" do
+    it "returns the title from the most recent edition" do
+      document = create(:block_document, block_type: "time_period")
+      create(:time_period_edition, document: document, title: "First Edition", created_at: 1.day.ago)
+      create(:time_period_edition, document: document, title: "Latest Edition", created_at: Time.current)
+
+      expect(document.title).to eq("Latest Edition")
+    end
+
+    it "returns nil when there are no editions" do
+      document = create(:block_document, block_type: "time_period")
+
+      expect(document.title).to be_nil
+    end
+  end
+end

--- a/spec/unit/app/models/block/edition_spec.rb
+++ b/spec/unit/app/models/block/edition_spec.rb
@@ -29,7 +29,40 @@ RSpec.describe Block::Edition, type: :model do
   describe "validations" do
     subject { concrete_edition_class.new(title: "Other Type Title") }
 
+    let(:document) { Block::Document.create!(sluggable_string: "test-block", block_type: "time_period") }
+
     it { is_expected.to validate_presence_of(:title) }
+
+    describe "title alphanumeric validation" do
+      it "is valid when title contains letters" do
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:)
+        expect(edition).to be_valid
+      end
+
+      it "is valid when title contains numbers" do
+        edition = concrete_edition_class.new(title: "2024", lead_organisation_id: SecureRandom.uuid, document:)
+        expect(edition).to be_valid
+      end
+
+      it "is invalid when title contains only special characters" do
+        edition = concrete_edition_class.new(title: "---", lead_organisation_id: SecureRandom.uuid, document:)
+        edition.valid?
+        expect(edition.errors[:title]).to include("must contain at least one letter or number")
+      end
+    end
+
+    describe "lead_organisation_id presence validation" do
+      it "is invalid when lead_organisation_id is blank" do
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: nil, document:)
+        edition.valid?
+        expect(edition.errors[:lead_organisation_id]).to include("cannot be blank")
+      end
+
+      it "is valid when lead_organisation_id is present" do
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:)
+        expect(edition).to be_valid
+      end
+    end
   end
 
   describe "#details" do

--- a/spec/unit/app/models/block/edition_spec.rb
+++ b/spec/unit/app/models/block/edition_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Block::Edition, type: :model do
+  # Since Edition is abstract, we need a concrete subclass for testing
+  let(:concrete_edition_class) do
+    Class.new(Block::Edition) do
+      def self.name
+        "Block::OtherTypeEdition"
+      end
+
+      def details
+        { "field_1" => "value 1" }
+      end
+    end
+  end
+
+  # Another concrete subclass, this one missing the #details implementation
+  let(:edition_class_missing_implementation) do
+    Class.new(Block::Edition) do
+      def self.name
+        "Block::MissingImplementationEdition"
+      end
+    end
+  end
+
+  describe "associations" do
+    subject { concrete_edition_class.new(title: "Other Type Title") }
+    it { is_expected.to belong_to(:document).class_name("Block::Document") }
+  end
+
+  describe "validations" do
+    subject { concrete_edition_class.new(title: "Other Type Title") }
+
+    it { is_expected.to validate_presence_of(:title) }
+  end
+
+  describe "#details" do
+    it "raises NotImplementedError when called on class with no #details method" do
+      expect { edition_class_missing_implementation.new.details }.to raise_error(
+        NotImplementedError, "Subclasses must implement #details method"
+      )
+    end
+
+    it "can be implemented by subclasses" do
+      document = Block::Document.create!(sluggable_string: "other-type-block", block_type: "time_period")
+      edition = concrete_edition_class.new(
+        document: document,
+        title: "Other Type Title",
+      )
+      expect(edition.details).to eq({ "field_1" => "value 1" })
+    end
+  end
+end

--- a/spec/unit/app/models/block/time_period_date_range_spec.rb
+++ b/spec/unit/app/models/block/time_period_date_range_spec.rb
@@ -11,6 +11,28 @@ RSpec.describe Block::TimePeriodDateRange, type: :model do
     it { is_expected.to validate_presence_of(:start) }
     it { is_expected.to validate_presence_of(:end) }
 
+    describe "invalid date validation" do
+      it "is invalid when start date has invalid month" do
+        date_range = described_class.new(edition: edition)
+        # Simulate multiparameter assignment with invalid month (23)
+        date_range.start = { 1 => 2025, 2 => 23, 3 => 6, 4 => 0, 5 => 0 }
+        date_range.end = Time.zone.parse("2026-04-05 23:59")
+
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:start]).to include("Start date is not a valid date")
+      end
+
+      it "is invalid when end date has invalid day" do
+        date_range = described_class.new(edition: edition)
+        date_range.start = Time.zone.parse("2025-04-06 00:00")
+        # Simulate multiparameter assignment with invalid day (32)
+        date_range.end = { 1 => 2025, 2 => 4, 3 => 32, 4 => 23, 5 => 59 }
+
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:end]).to include("End date is not a valid date")
+      end
+    end
+
     describe "end_date_after_start_date" do
       it "is invalid when end is before start" do
         date_range = described_class.new(

--- a/spec/unit/app/models/block/time_period_date_range_spec.rb
+++ b/spec/unit/app/models/block/time_period_date_range_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe Block::TimePeriodDateRange, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:edition).class_name("Block::TimePeriodEdition") }
+  end
+
+  describe "validations" do
+    let(:edition) { create(:time_period_edition) }
+
+    subject { described_class.new(edition: edition, start: Time.zone.parse("2025-04-06 00:00"), end: Time.zone.parse("2026-04-05 23:59")) }
+
+    it { is_expected.to validate_presence_of(:start) }
+    it { is_expected.to validate_presence_of(:end) }
+
+    describe "end_date_after_start_date" do
+      it "is invalid when end is before start" do
+        date_range = described_class.new(
+          edition: edition,
+          start: Time.zone.parse("2025-04-06 00:00"),
+          end: Time.zone.parse("2025-04-05 23:59"),
+        )
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:end]).to include("must be after start date")
+      end
+
+      it "is invalid when end equals start" do
+        same_time = Time.zone.parse("2025-04-06 00:00")
+        date_range = described_class.new(
+          edition: edition,
+          start: same_time,
+          end: same_time,
+        )
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:end]).to include("must be after start date")
+      end
+
+      it "is valid when end is after start" do
+        date_range = described_class.new(
+          edition: edition,
+          start: Time.zone.parse("2025-04-06 00:00"),
+          end: Time.zone.parse("2026-04-05 23:59"),
+        )
+        expect(date_range).to be_valid
+      end
+    end
+  end
+
+  describe "#to_details" do
+    it "returns hash with formatted start and end date/time" do
+      date_range = described_class.new(
+        start: Time.zone.parse("2025-04-06 00:00"),
+        end: Time.zone.parse("2026-04-05 23:59"),
+      )
+
+      expect(date_range.to_details).to eq({
+        "start" => {
+          "date" => "2025-04-06",
+          "time" => "00:00",
+        },
+        "end" => {
+          "date" => "2026-04-05",
+          "time" => "23:59",
+        },
+      })
+    end
+
+    it "formats times with leading zeros" do
+      date_range = described_class.new(
+        start: Time.zone.parse("2025-01-01 09:05"),
+        end: Time.zone.parse("2025-12-31 18:30"),
+      )
+
+      result = date_range.to_details
+      expect(result["start"]["time"]).to eq("09:05")
+      expect(result["end"]["time"]).to eq("18:30")
+    end
+  end
+end

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Block::TimePeriodEdition, type: :model do
+  describe "inheritance" do
+    it "inherits from Block::Edition" do
+      expect(described_class.superclass).to eq(Block::Edition)
+    end
+
+    it "uses STI with correct type value" do
+      document = Block::Document.create!(sluggable_string: "test-block", block_type: "time_period")
+      edition = described_class.create!(
+        document: document,
+        title: "Test Time Period",
+      )
+
+      expect(edition.type).to eq("Block::TimePeriodEdition")
+      expect(Block::Edition.find(edition.id)).to be_a(Block::TimePeriodEdition)
+    end
+  end
+
+  describe "validations" do
+    it "inherits title presence validation from Block::Edition" do
+      edition = described_class.new(title: nil)
+      expect(edition).not_to be_valid
+      expect(edition.errors[:title]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -5,10 +5,14 @@ RSpec.describe Block::TimePeriodEdition, type: :model do
     end
 
     it "uses STI with correct type value" do
-      document = Block::Document.create!(sluggable_string: "test-block", block_type: "time_period")
+      document = Block::Document.create!(
+        sluggable_string: "test-block",
+        block_type: "time_period",
+      )
       edition = described_class.create!(
         document: document,
         title: "Test Time Period",
+        lead_organisation_id: SecureRandom.uuid,
       )
 
       expect(edition.type).to eq("Block::TimePeriodEdition")
@@ -24,7 +28,7 @@ RSpec.describe Block::TimePeriodEdition, type: :model do
     it "inherits title presence validation from Block::Edition" do
       edition = described_class.new(title: nil)
       expect(edition).not_to be_valid
-      expect(edition.errors[:title]).to include("can't be blank")
+      expect(edition.errors[:title]).to include("cannot be blank")
     end
   end
 

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -16,11 +16,87 @@ RSpec.describe Block::TimePeriodEdition, type: :model do
     end
   end
 
+  describe "associations" do
+    it { is_expected.to have_one(:date_range).class_name("Block::TimePeriodDateRange").dependent(:destroy) }
+  end
+
   describe "validations" do
     it "inherits title presence validation from Block::Edition" do
       edition = described_class.new(title: nil)
       expect(edition).not_to be_valid
       expect(edition.errors[:title]).to include("can't be blank")
+    end
+  end
+
+  describe "nested attributes" do
+    it "accepts nested attributes for date_range" do
+      edition = create(:time_period_edition)
+
+      edition.update!(
+        date_range_attributes: {
+          start: Time.zone.parse("2025-04-06 00:00"),
+          end: Time.zone.parse("2026-04-05 23:59"),
+        },
+      )
+
+      expect(edition.date_range).to be_present
+      expect(edition.date_range.start).to eq(Time.zone.parse("2025-04-06 00:00"))
+      expect(edition.date_range.end).to eq(Time.zone.parse("2026-04-05 23:59"))
+    end
+  end
+
+  describe "#details" do
+    it "returns hash with description and date_range details" do
+      date_range = build(:block_time_period_date_range,
+                         start: Time.zone.parse("2025-04-06 00:00"),
+                         end: Time.zone.parse("2026-04-05 23:59"))
+      edition = build(:time_period_edition,
+                      description: "Tax year 2025/26",
+                      date_range: date_range)
+
+      expect(edition.details).to eq({
+        "description" => "Tax year 2025/26",
+        "date_range" => {
+          "start" => {
+            "date" => "2025-04-06",
+            "time" => "00:00",
+          },
+          "end" => {
+            "date" => "2026-04-05",
+            "time" => "23:59",
+          },
+        },
+      })
+    end
+
+    it "returns hash with only description when date_range is nil" do
+      edition = build(:time_period_edition, description: "Tax year 2025/26")
+
+      expect(edition.details).to eq({
+        "description" => "Tax year 2025/26",
+      })
+    end
+
+    it "returns hash with only date_range when description is nil" do
+      date_range = build(:block_time_period_date_range,
+                         start: Time.zone.parse("2025-04-06 00:00"),
+                         end: Time.zone.parse("2026-04-05 23:59"))
+      edition = build(:time_period_edition,
+                      description: nil,
+                      date_range: date_range)
+
+      expect(edition.details).to eq({
+        "date_range" => {
+          "start" => {
+            "date" => "2025-04-06",
+            "time" => "00:00",
+          },
+          "end" => {
+            "date" => "2026-04-05",
+            "time" => "23:59",
+          },
+        },
+      })
     end
   end
 end


### PR DESCRIPTION
See the ADR (which is the first commit) for an overview of this experiment:

---

# 11. Experiment with Traditional ActiveRecord Models for Content Blocks

Date: 2026-03-11

Status: Experimental

## Context

### Current State

The Content Block Manager currently uses a **schema-driven generic approach** for modeling content blocks:

1. **Single Document Model:** All block types use a single `Document` model (no subclasses).
2. **Single Edition Model:** All block types use a single `Edition` model with a generic `details` JSON column.
3. **JSON Schema Validation:** Block type structure is defined and validated via JSON schemas stored in `app/models/schema/definitions/*.json`.
4. **Generic Forms:** Form interfaces are dynamically generated from the JSON schemas.

This architecture provides flexibility and allows new block types to be added by defining a JSON schema without creating new models or migrations.

This was a necessary technical design initially as all schemas were defined in Publishing API. However, in order to have greater control, particularly over validation, we've recently moved the schema into this repository (See [ADR 10 Make Content Block Manager the source of truth for schemas][])

The use of JSON schema definition is no longer a requirement.

### The Question

As the application grows, we're evaluating whether the schema-driven approach provides the best developer experience and maintainability, or whether a **traditional Rails ActiveRecord approach** with dedicated models and tables might be clearer and easier to work with.

Specifically, we want to understand:

2. **Developer Experience:** Is it easier and faster to work with explicit Rails models and associations vs. generic JSON columns? Our experience when adding a new block type is that there are numerous differences or additional features which are needed. At face value they appear minor but in reality prove complex to introduce to an application model which is entirely generic. Our small number of classes can do everything, but at what price in terms of complexity and cognitive load.
3. **Maintainability:** Are dedicated models with typed columns easier to understand and modify than schema definitions?
4. **Adding Fields:** Is it simpler to add a migration for a new column vs. updating a JSON schema?
5. **Performance:** Do typed columns with proper indexes perform better than querying within JSON?
6. **Testing:** Are traditional model tests more straightforward than testing schema validation?

## Decision

We will conduct an **experiment** by implementing an alternative architecture using traditional ActiveRecord models, running **in parallel** with the existing schema-driven system.

### Experiment Scope

We will implement the **TimePeriod** block type as a proof-of-concept using the new architecture. This will allow us to:

- Compare both approaches side-by-side in the same codebase
- Evaluate real-world developer experience
- Make an informed decision about which direction to pursue

This is **not yet** a decision to migrate away from the existing schema-based paradigm - it is purely exploratory.

---

## Current state

<img width="1231" height="1325" alt="current_state" src="https://github.com/user-attachments/assets/fd54914e-2be2-4fac-a072-ef43b7fd7363" />

## Proposed target state

<img width="1787" height="1756" alt="proposed_target_state" src="https://github.com/user-attachments/assets/f08652ad-896f-4445-8751-349140b021c1" />


---

To try this out locally you can either:

## 1. Use some conditionally applied UI elements

See some conditional UI elements by giving yourself the `schemaless_experiment` permission:

```rb
User.last.permissions << `schemaless_experiment`
User.last.save
``` 

or by adding `?schemaless_experiment=true` to your URL

## 2. Navigate manually to the new-style TimePeriod form

`/block/time_period_editions/new`

<img width="713" height="791" alt="new_time_period_edition_form" src="https://github.com/user-attachments/assets/e6d2ac07-4194-4c8f-9b32-7074f6ffc35d" />


## Screenshot of new style TimePeriod


<img width="779" height="724" alt="new_style_time_period" src="https://github.com/user-attachments/assets/b4db9aa3-3a32-448c-916d-c09b425c0978" />


