### PR TITLE
(CM-904) Show diff of content in previews

### DIFF
--- a/app/assets/stylesheets/nokodiff_preview.scss
+++ b/app/assets/stylesheets/nokodiff_preview.scss
@@ -1,0 +1,1 @@
+@import "nokodiff";

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,5 +1,6 @@
 Rails.application.config.dartsass.builds = {
   "application.scss" => "application.css",
+  "nokodiff_preview.scss" => "nokodiff.css",
 }
 
 Rails.application.config.dartsass.build_options << " --quiet-deps --silence-deprecation=import --silence-deprecation=mixed-decls"

--- a/engines/block_preview/app/assets/config/manifest.js
+++ b/engines/block_preview/app/assets/config/manifest.js
@@ -1,1 +1,2 @@
 //= link host-content-iframe.js
+//= link nokodiff.css

--- a/engines/block_preview/app/model/block_preview/content_diff.rb
+++ b/engines/block_preview/app/model/block_preview/content_diff.rb
@@ -1,0 +1,37 @@
+class BlockPreview::ContentDiff
+  def initialize(html, block)
+    @before = html.at_css('[data-module="govspeak"]')
+    @block = block
+  end
+
+  delegate :to_s, to: :diff_fragment
+
+private
+
+  attr_reader :before, :block
+
+  def diff_fragment
+    @diff_fragment ||= begin
+      fragment = Nokogiri::HTML.fragment(Nokodiff.diff(before, after))
+      fragment.children.first.add_class("compare-editions")
+    end
+  end
+
+  def after
+    @after ||= build_after_fragment
+  end
+
+  def build_after_fragment
+    fragment = before.dup
+
+    fragment.css(content_block_selector).each do |wrapper|
+      wrapper.replace(block.render(wrapper["data-embed-code"]))
+    end
+
+    fragment
+  end
+
+  def content_block_selector
+    %([data-content-id="#{block.content_id}"])
+  end
+end

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -23,7 +23,8 @@ module BlockPreview
       add_draft_style(nokogiri_html)
       update_css_hrefs(nokogiri_html)
       update_js_srcs(nokogiri_html)
-      nokogiri_html.at_css("[data-module=\"govspeak\"]").replace BlockPreview::ContentDiff.new(nokogiri_html, block).to_s
+      add_nokodiff_stylesheet(nokogiri_html)
+      update_preview_with_diff(nokogiri_html)
       update_local_link_paths(nokogiri_html)
       update_local_form_actions(nokogiri_html, uri.scheme, uri.host)
       nokogiri_html.to_s
@@ -134,10 +135,28 @@ module BlockPreview
       nokogiri_html
     end
 
+    def update_preview_with_diff(nokogiri_html)
+      nokogiri_html.at_css("[data-module=\"govspeak\"]")
+                   .replace(
+                     BlockPreview::ContentDiff.new(nokogiri_html, block).to_s,
+                   )
 
-
+      nokogiri_html
     end
 
+    def add_nokodiff_stylesheet(nokogiri_html)
+      head = nokogiri_html.at_css("head")
+      return nokogiri_html unless head
+
+      href = nokodiff_stylesheet_href
+      return nokogiri_html if head.at_css("link[rel='stylesheet'][href='#{href}']")
+
+      head.add_child(Nokogiri::HTML::DocumentFragment.parse(%(<link rel="stylesheet" href="#{href}">)))
+      nokogiri_html
+    end
+
+    def nokodiff_stylesheet_href
+      ActionController::Base.helpers.asset_path("nokodiff.css")
     end
 
     def auth_bypass_token

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -6,6 +6,8 @@ module BlockPreview
   class PreviewHtml
     include BlockPreview::Engine.routes.url_helpers
 
+    ERROR_HTML = "<html><head></head><body><p>Preview not found</p></body></html>".freeze
+
     def initialize(content_id:, block:, base_path:, locale:, state:, auth_bypass_id:)
       @content_id = content_id
       @block = block
@@ -18,18 +20,16 @@ module BlockPreview
     def to_s
       uri = Addressable::URI.parse(frontend_path)
       nokogiri_html = html_snapshot_from_frontend(uri)
-      update_local_link_paths(nokogiri_html)
-      update_local_form_actions(nokogiri_html, uri.scheme, uri.host)
       add_draft_style(nokogiri_html)
       update_css_hrefs(nokogiri_html)
       update_js_srcs(nokogiri_html)
-      replace_existing_content_blocks(nokogiri_html).to_s
+      nokogiri_html.at_css("[data-module=\"govspeak\"]").replace BlockPreview::ContentDiff.new(nokogiri_html, block).to_s
+      update_local_link_paths(nokogiri_html)
+      update_local_form_actions(nokogiri_html, uri.scheme, uri.host)
+      nokogiri_html.to_s
     end
 
   private
-
-    BLOCK_STYLE = "background-color: yellow;".freeze
-    ERROR_HTML = "<html><head></head><body><p>Preview not found</p></body></html>".freeze
 
     attr_reader :block, :content_id, :base_path, :locale, :state, :auth_bypass_id
 
@@ -134,27 +134,10 @@ module BlockPreview
       nokogiri_html
     end
 
-    def replace_existing_content_blocks(nokogiri_html)
-      replace_blocks(nokogiri_html)
-      style_blocks(nokogiri_html)
-      nokogiri_html
+
+
     end
 
-    def replace_blocks(nokogiri_html)
-      content_block_wrappers(nokogiri_html).each do |wrapper|
-        embed_code = wrapper["data-embed-code"]
-        wrapper.replace block.render(embed_code)
-      end
-    end
-
-    def style_blocks(nokogiri_html)
-      content_block_wrappers(nokogiri_html).each do |wrapper|
-        wrapper["style"] = BLOCK_STYLE
-      end
-    end
-
-    def content_block_wrappers(nokogiri_html)
-      nokogiri_html.css("[data-content-id=\"#{block.content_id}\"]")
     end
 
     def auth_bypass_token

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -8,6 +8,8 @@ module BlockPreview
 
     ERROR_HTML = "<html><head></head><body><p>Preview not found</p></body></html>".freeze
 
+    class HtmlSnapshotError < StandardError; end
+
     def initialize(content_id:, block:, base_path:, locale:, state:, auth_bypass_id:)
       @content_id = content_id
       @block = block
@@ -28,6 +30,8 @@ module BlockPreview
       update_local_link_paths(nokogiri_html)
       update_local_form_actions(nokogiri_html, uri.scheme, uri.host)
       nokogiri_html.to_s
+    rescue HtmlSnapshotError
+      ERROR_HTML
     end
 
   private
@@ -71,13 +75,13 @@ module BlockPreview
     end
 
     def html_snapshot_from_frontend(uri)
-      begin
-        uri = add_auth_bypass_token_to_uri(uri) if draft?
-        raw_html = Net::HTTP.get(uri)
-      rescue StandardError
-        raw_html = ERROR_HTML
+      uri = add_auth_bypass_token_to_uri(uri) if draft?
+      response = Net::HTTP.get_response(uri)
+      if response.code == "200"
+        Nokogiri::HTML.parse(response.body)
+      else
+        raise HtmlSnapshotError
       end
-      Nokogiri::HTML.parse(raw_html)
     end
 
     def add_auth_bypass_token_to_uri(uri)

--- a/engines/block_preview/spec/unit/app/models/content_diff_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/content_diff_spec.rb
@@ -1,0 +1,139 @@
+RSpec.describe BlockPreview::ContentDiff do
+  subject(:content_diff) { described_class.new(html, block) }
+
+  let(:content_id) { SecureRandom.uuid }
+  let(:block) { instance_double("ContentBlock", content_id:) }
+
+  describe "#to_s" do
+    context "when govspeak includes a matching embedded content block" do
+      let(:html) do
+        Nokogiri::HTML.parse(<<~HTML)
+          <html>
+            <body>
+              <div data-module="govspeak">
+                <p>Before content</p>
+                <span data-content-id="#{content_id}" data-embed-code="embed-1">Old block</span>
+              </div>
+            </body>
+          </html>
+        HTML
+      end
+
+      before do
+        allow(block).to receive(:render).with("embed-1").and_return("<span>Rendered block</span>")
+      end
+
+      it "returns a diff fragment marked with compare-editions" do
+        parsed = Nokogiri::HTML.fragment(content_diff.to_s)
+
+        expect(parsed.at_css(".compare-editions")).to be_present
+      end
+
+      it "renders the replacement content in the diff output" do
+        parsed = Nokogiri::HTML.fragment(content_diff.to_s)
+
+        expect(parsed.text).to include("Rendered block")
+      end
+    end
+
+    context "when govspeak has both matching and non-matching embedded blocks" do
+      let(:other_content_id) { SecureRandom.uuid }
+      let(:html) do
+        Nokogiri::HTML.parse(<<~HTML)
+          <html>
+            <body>
+              <div data-module="govspeak">
+                <span data-content-id="#{content_id}" data-embed-code="embed-1">Old matching block</span>
+                <span data-content-id="#{other_content_id}" data-embed-code="embed-2">Old non-matching block</span>
+              </div>
+            </body>
+          </html>
+        HTML
+      end
+
+      before do
+        allow(block).to receive(:render).with("embed-1").and_return("<span>Rendered matching block</span>")
+      end
+
+      it "only renders replacements for wrappers with the target content id" do
+        content_diff.to_s
+
+        expect(block).to have_received(:render).with("embed-1").once
+      end
+
+      it "keeps non-matching content visible in the resulting diff" do
+        parsed = Nokogiri::HTML.fragment(content_diff.to_s)
+
+        expect(parsed.text).to include("Old non-matching block")
+      end
+    end
+
+    context "when multiple wrappers match the target content id" do
+      let(:html) do
+        Nokogiri::HTML.parse(<<~HTML)
+          <html>
+            <body>
+              <div data-module="govspeak">
+                <span data-content-id="#{content_id}" data-embed-code="embed-1">Old block 1</span>
+                <span data-content-id="#{content_id}" data-embed-code="embed-2">Old block 2</span>
+              </div>
+            </body>
+          </html>
+        HTML
+      end
+
+      before do
+        allow(block).to receive(:render).with("embed-1").and_return("<span>Rendered block 1</span>")
+        allow(block).to receive(:render).with("embed-2").and_return("<span>Rendered block 2</span>")
+      end
+
+      it "renders each matching wrapper using its embed code" do
+        content_diff.to_s
+
+        expect(block).to have_received(:render).with("embed-1").once
+        expect(block).to have_received(:render).with("embed-2").once
+      end
+    end
+
+    context "when a matching wrapper has no embed code" do
+      let(:html) do
+        Nokogiri::HTML.parse(<<~HTML)
+          <html>
+            <body>
+              <div data-module="govspeak">
+                <span data-content-id="#{content_id}">Old block</span>
+              </div>
+            </body>
+          </html>
+        HTML
+      end
+
+      before do
+        allow(block).to receive(:render).with(nil).and_return("<span>Rendered without embed code</span>")
+      end
+
+      it "passes nil to the renderer and still returns output" do
+        output = content_diff.to_s
+
+        expect(block).to have_received(:render).with(nil)
+        expect(output).to include("compare-editions")
+      end
+    end
+
+    context "when the source html has no govspeak node" do
+      let(:html) do
+        Nokogiri::HTML.parse(<<~HTML)
+          <html>
+            <body>
+              <p>No govspeak content here</p>
+            </body>
+          </html>
+        HTML
+      end
+
+      it "raises an error when generating the diff" do
+        expect { content_diff.to_s }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe BlockPreview::PreviewHtml do
     expect(parsed_content.at_css("script[src='#{Plek.website_root}/assets/application.js']")).to be_present
   end
 
+  it "injects the nokodiff stylesheet from the local asset pipeline" do
+    actual_content = BlockPreview::PreviewHtml.new(
+      content_id: host_content_id,
+      block: block_to_preview,
+      base_path: host_base_path,
+      locale: "en",
+      state: "published",
+      auth_bypass_id:,
+    ).to_s
+
+    parsed_content = Nokogiri::HTML.parse(actual_content)
+    hrefs = parsed_content.css("head link[rel='stylesheet']").map { |link| link["href"] }
+
+    expect(hrefs).to include("/assets/content-block-manager/nokodiff.css")
+  end
+
   describe "when the frontend throws an error" do
     before do
       exception = StandardError.new("Something went wrong")

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BlockPreview::PreviewHtml do
   let(:host_base_path) { "/test" }
   let(:uri_mock) { double }
 
-  let(:fake_body) do
+  let(:fake_content) do
     <<-HTML
     <div class=\"govuk-body\">
         <p>test</p>
@@ -21,7 +21,7 @@ RSpec.describe BlockPreview::PreviewHtml do
     HTML
   end
 
-  let(:fake_frontend_response) do
+  let(:fake_body) do
     <<-HTML
       <head>
         <link rel="stylesheet" href="/assets/application.css">
@@ -29,10 +29,18 @@ RSpec.describe BlockPreview::PreviewHtml do
       </head>
       <body class="govuk-body">
         <div data-module=\"govspeak\">
-          #{fake_body}
+          #{fake_content}
         </div>
       </body>
     HTML
+  end
+
+  let(:fake_frontend_response) do
+    instance_double(
+      "Net::HTTPResponse",
+      code: "200",
+      body: fake_body,
+    )
   end
 
   let(:block_render) do
@@ -49,11 +57,11 @@ RSpec.describe BlockPreview::PreviewHtml do
 
   let(:auth_bypass_id) { SecureRandom.uuid }
   let(:token) { "token" }
-  let(:content_diff_spy) { double("BlockPreview::ContentDiff", to_s: fake_body) }
+  let(:content_diff_spy) { double("BlockPreview::ContentDiff", to_s: fake_content) }
 
   before do
     allow(JWT).to receive(:encode).and_return(token)
-    allow(Net::HTTP).to receive(:get).and_return(fake_frontend_response)
+    allow(Net::HTTP).to receive(:get_response).and_return(fake_frontend_response)
     allow(BlockPreview::ContentDiff).to receive(:new).and_return(content_diff_spy)
   end
 
@@ -67,7 +75,7 @@ RSpec.describe BlockPreview::PreviewHtml do
       auth_bypass_id:,
     ).to_s
 
-    expect(Net::HTTP).to have_received(:get) do |url|
+    expect(Net::HTTP).to have_received(:get_response) do |url|
       expect(url.host).to eq(Plek.website_root.sub("http://", ""))
       expect(url.path).to eq(host_base_path)
     end
@@ -83,7 +91,7 @@ RSpec.describe BlockPreview::PreviewHtml do
       auth_bypass_id:,
     ).to_s
 
-    expect(Net::HTTP).to have_received(:get) do |url|
+    expect(Net::HTTP).to have_received(:get_response) do |url|
       expect(url.query_values).to be_nil
     end
   end
@@ -140,10 +148,12 @@ RSpec.describe BlockPreview::PreviewHtml do
     expect(hrefs).to include("/assets/content-block-manager/nokodiff.css")
   end
 
-  describe "when the frontend throws an error" do
-    before do
-      exception = StandardError.new("Something went wrong")
-      allow(Net::HTTP).to receive(:get).and_raise(exception)
+  describe "when the frontend returns a non-200 response" do
+    let(:fake_frontend_response) do
+      instance_double(
+        "Net::HTTPResponse",
+        code: "500",
+      )
     end
 
     it "shows an error template" do
@@ -161,7 +171,7 @@ RSpec.describe BlockPreview::PreviewHtml do
   end
 
   describe "when the frontend response contains links" do
-    let(:fake_body) do
+    let(:fake_content) do
       "
         <a href='/foo'>Internal link</a>
         <a href='https://example.com'>External link</a>
@@ -231,7 +241,7 @@ RSpec.describe BlockPreview::PreviewHtml do
   end
 
   describe "when the frontend response contains forms" do
-    let(:fake_body) do
+    let(:fake_content) do
       "
         <main>
           <form action='/foo' method='get'>
@@ -275,7 +285,7 @@ RSpec.describe BlockPreview::PreviewHtml do
   end
 
   describe "when the wrapper is a div" do
-    let(:fake_body) do
+    let(:fake_content) do
       "<p>test</p><div class=\"content-embed content-embed__content_block_contact\" data-content-block=\"\" data-document-type=\"content_block_contact\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\">example@example.com</div>"
     end
     let(:block_render) do
@@ -324,7 +334,7 @@ RSpec.describe BlockPreview::PreviewHtml do
     end
 
     it "makes a request to the draft origin" do
-      expect(Net::HTTP).to have_received(:get) do |url|
+      expect(Net::HTTP).to have_received(:get_response) do |url|
         host_with_scheme = "#{url.scheme}://#{url.host}"
         expect(host_with_scheme).to eq(Plek.external_url_for("draft-origin"))
         expect(url.path).to eq(host_base_path)
@@ -345,7 +355,7 @@ RSpec.describe BlockPreview::PreviewHtml do
     end
 
     it "appends the token to the url" do
-      expect(Net::HTTP).to have_received(:get) do |url|
+      expect(Net::HTTP).to have_received(:get_response) do |url|
         expect(url.query_values).to eq({ "token" => token })
       end
     end
@@ -393,7 +403,7 @@ RSpec.describe BlockPreview::PreviewHtml do
         auth_bypass_id:,
       ).to_s
 
-      expect(Net::HTTP).to have_received(:get) do |url|
+      expect(Net::HTTP).to have_received(:get_response) do |url|
         expect(url.host).to eq(Plek.external_url_for(rendering_app).sub("http://", ""))
         expect(url.path).to eq(host_base_path)
       end
@@ -416,7 +426,7 @@ RSpec.describe BlockPreview::PreviewHtml do
           auth_bypass_id:,
         ).to_s
 
-        expect(Net::HTTP).to have_received(:get) do |url|
+        expect(Net::HTTP).to have_received(:get_response) do |url|
           expect(url.host).to eq(Plek.external_url_for("frontend").sub("http://", ""))
           expect(url.path).to eq(host_base_path)
         end
@@ -436,7 +446,7 @@ RSpec.describe BlockPreview::PreviewHtml do
           auth_bypass_id:,
         ).to_s
 
-        expect(Net::HTTP).to have_received(:get) do |url|
+        expect(Net::HTTP).to have_received(:get_response) do |url|
           expect(url.host).to eq(Plek.external_url_for("smart-answers").sub("http://", ""))
           expect(url.path).to eq(host_base_path)
         end
@@ -454,7 +464,7 @@ RSpec.describe BlockPreview::PreviewHtml do
           auth_bypass_id:,
         ).to_s
 
-        expect(Net::HTTP).to have_received(:get) do |url|
+        expect(Net::HTTP).to have_received(:get_response) do |url|
           expect(url.host).to eq(Plek.external_url_for("draft-#{rendering_app}").sub("http://", ""))
         end
       end
@@ -472,7 +482,7 @@ RSpec.describe BlockPreview::PreviewHtml do
             auth_bypass_id:,
           ).to_s
 
-          expect(Net::HTTP).to have_received(:get) do |url|
+          expect(Net::HTTP).to have_received(:get_response) do |url|
             expect(url.host).to eq(Plek.external_url_for("smart-answers").sub("http://", ""))
             expect(url.path).to eq(host_base_path)
           end
@@ -496,7 +506,7 @@ RSpec.describe BlockPreview::PreviewHtml do
             auth_bypass_id:,
           ).to_s
 
-          expect(Net::HTTP).to have_received(:get) do |url|
+          expect(Net::HTTP).to have_received(:get_response) do |url|
             expect(url.host).to eq(Plek.external_url_for("draft-frontend").sub("http://", ""))
             expect(url.path).to eq(host_base_path)
           end

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BlockPreview::PreviewHtml do
 
   let(:fake_body) do
     <<-HTML
-    <body class=\"govuk-body\">
+    <div class=\"govuk-body\">
         <p>test</p>
         <span
           class=\"content-embed content-embed__content_block_contact\"
@@ -17,7 +17,7 @@ RSpec.describe BlockPreview::PreviewHtml do
           data-document-type=\"content_block_contact\"
           data-embed-code=\"embed-code\"
           data-content-id=\"#{preview_content_id}\">example@example.com</span>
-      </body>
+    </div>
     HTML
   end
 
@@ -28,7 +28,9 @@ RSpec.describe BlockPreview::PreviewHtml do
         <script src="/assets/application.js"></script>/
       </head>
       <body class="govuk-body">
-        #{fake_body}
+        <div data-module=\"govspeak\">
+          #{fake_body}
+        </div>
       </body>
     HTML
   end
@@ -47,11 +49,12 @@ RSpec.describe BlockPreview::PreviewHtml do
 
   let(:auth_bypass_id) { SecureRandom.uuid }
   let(:token) { "token" }
+  let(:content_diff_spy) { double("BlockPreview::ContentDiff", to_s: fake_body) }
 
   before do
     allow(JWT).to receive(:encode).and_return(token)
     allow(Net::HTTP).to receive(:get).and_return(fake_frontend_response)
-    allow(block_to_preview).to receive(:render).and_return(block_render)
+    allow(BlockPreview::ContentDiff).to receive(:new).and_return(content_diff_spy)
   end
 
   it "makes a request to the frontend" do
@@ -98,7 +101,11 @@ RSpec.describe BlockPreview::PreviewHtml do
     parsed_content = Nokogiri::HTML.parse(actual_content)
 
     expect(parsed_content.at_css("body.gem-c-layout-for-public--draft")).to be_present
-    expect(parsed_content.at_css('span.content-embed__content_block_contact[style="background-color: yellow;"]')).to be_present
+    expect(BlockPreview::ContentDiff).to have_received(:new).with(
+      anything,
+      block_to_preview,
+    )
+    expect(content_diff_spy).to have_received(:to_s)
   end
 
   it "appends the base path to the CSS and JS references" do
@@ -124,8 +131,6 @@ RSpec.describe BlockPreview::PreviewHtml do
     end
 
     it "shows an error template" do
-      expected_content = Nokogiri::HTML.parse("<html><head></head><body class=\" gem-c-layout-for-public--draft\"><p>Preview not found</p></body></html>").to_s
-
       actual_content = BlockPreview::PreviewHtml.new(
         content_id: host_content_id,
         block: block_to_preview,
@@ -135,7 +140,7 @@ RSpec.describe BlockPreview::PreviewHtml do
         auth_bypass_id:,
       ).to_s
 
-      expect(actual_content).to eq(expected_content)
+      expect(actual_content).to eq(BlockPreview::PreviewHtml::ERROR_HTML)
     end
   end
 
@@ -274,7 +279,11 @@ RSpec.describe BlockPreview::PreviewHtml do
       parsed_content = Nokogiri::HTML.parse(actual_content)
 
       expect(parsed_content.at_css("body.gem-c-layout-for-public--draft")).to be_present
-      expect(parsed_content.at_css('div.content-embed__content_block_contact[style="background-color: yellow;"]')).to be_present
+      expect(BlockPreview::ContentDiff).to have_received(:new).with(
+        anything,
+        block_to_preview,
+      )
+      expect(content_diff_spy).to have_received(:to_s)
     end
   end
 
@@ -329,7 +338,11 @@ RSpec.describe BlockPreview::PreviewHtml do
       parsed_content = Nokogiri::HTML.parse(actual_content)
 
       expect(parsed_content.at_css("body.gem-c-layout-for-public--draft")).to be_present
-      expect(parsed_content.at_css('span.content-embed__content_block_contact[style="background-color: yellow;"]')).to be_present
+      expect(BlockPreview::ContentDiff).to have_received(:new).with(
+        anything,
+        block_to_preview,
+      )
+      expect(content_diff_spy).to have_received(:to_s)
     end
 
     it "appends the draft-origin base path to the CSS and JS references" do

--- a/features/step_definitions/preview_steps.rb
+++ b/features/step_definitions/preview_steps.rb
@@ -27,7 +27,7 @@ def create_host_document(state)
     "#{website_root}#{@current_host_document['base_path']}",
   ).with(query: { token: }.compact).to_return(
     status: 200,
-    body: "<head></head><body><h1>#{@current_host_document['title']}</h1><p>iframe preview <a href=\"/other-page\">Link to other page</a></p>#{@content_block.render(embed_code)}</body>",
+    body: "<head></head><body><div data-module=\"govspeak\"><h1>#{@current_host_document['title']}</h1><p>iframe preview <a href=\"/other-page\">Link to other page</a></p>#{@content_block.render(embed_code)}</div></body>",
   )
 
   stub_request(
@@ -35,7 +35,7 @@ def create_host_document(state)
     "#{website_root}/other-page",
   ).with(query: { token: }.compact).to_return(
     status: 200,
-    body: "<head></head><body><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render(embed_code)}</body>",
+    body: "<head></head><body><div data-module=\"govspeak\"><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render(embed_code)}</div></body>",
   )
 end
 
@@ -69,10 +69,12 @@ Given("there is a host document that is a smart answer") do
       <head></head>
       <body><h1>#{@current_host_document['title']}</h1>
       <main>
-        <form action="/smart-answer" method="post">
-          <input type="text" name="name" id="name" />
-          <button type="submit">Submit</button>
-        </form>
+        <div data-module="govspeak">
+          <form action="/smart-answer" method="post">
+            <input type="text" name="name" id="name" />
+            <button type="submit">Submit</button>
+          </form>
+        </div>
       </main>
       </body>
     </html>
@@ -94,7 +96,7 @@ Given("there is a host document that is a smart answer") do
     "#{Plek.website_root}/smart-answer/result",
   ).to_return(
     status: 200,
-    body: "<head></head><body><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render(embed_code)}</body>",
+    body: "<head></head><body><div data-module=\"govspeak\"><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render(embed_code)}</div></body>",
   )
 end
 


### PR DESCRIPTION
This improves the previews to show a diff of the content where blocks are used, rather than just highlighting the blocks in question. 

~~NOTE: At the moment, diffs within headings aren't rendering correctly. Need to fix this upstream, and also check with Mainstream if any proposed fix messes with any of their use cases.~~

## Screenshot

<img width="1920" height="1946" alt="2026-04-09 14 44 01 content-block-manager integration publishing service gov uk b62c66cac31c" src="https://github.com/user-attachments/assets/24400b44-627d-4633-a545-2c6e4a7ac251" />

