### PR TITLE
Fix Opentelemetry error in non-dev environments

### DIFF
--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -76,7 +76,8 @@ module BlockPreview
 
     def html_snapshot_from_frontend(uri)
       uri = add_auth_bypass_token_to_uri(uri) if draft?
-      response = Net::HTTP.get_response(uri)
+      # Net::HTTP.get_response doesn't work with Addressable::URI, so we need to convert it to a standard URI
+      response = Net::HTTP.get_response(URI.parse(uri.to_s))
       if response.code == "200"
         Nokogiri::HTML.parse(response.body)
       else

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe BlockPreview::PreviewHtml do
     ).to_s
 
     expect(Net::HTTP).to have_received(:get_response) do |url|
-      expect(url.query_values).to be_nil
+      expect(url.query).to be_nil
     end
   end
 
@@ -356,7 +356,7 @@ RSpec.describe BlockPreview::PreviewHtml do
 
     it "appends the token to the url" do
       expect(Net::HTTP).to have_received(:get_response) do |url|
-        expect(url.query_values).to eq({ "token" => token })
+        expect(url.query).to eq("token=#{token}")
       end
     end
 


### PR DESCRIPTION
Before, we were passing an `Addressable::URI` object when fetching the response. This works, `Addresable::URI` behaving much like a `URI` object.

However, the resulting URI’s `path` is returned as an `Addressable::URI` object, which, due to a recent change in the OpenTelemetry’s `Net::HTTP` patch is expected to be a string, resulting in the following error:

```
NoMethodError

undefined method 'split' for an instance of Addressable::URI (NoMethodError)

                path_and_query = path.split('?')
```

(See https://govuk.sentry.io/issues/7410399614/?alert_rule_id=16268979&alert_type=issue&notification_uuid=c4ac75e5-51e7-41c7-8f7a-1493a60b91d9&project=4509943744692224&referrer=slack)

We get around this by converting the uri object into a plain old `URI` when making the request. This should ensure the telemetry middleware can handle the URI correctly.