### PR TITLE
(CM-925) Add a cooldown period to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,23 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3
+    exclude: # Exclude GDS-managed gems from the cooldown period
+      - govuk_*
+      - content_block_tools
+      - nokodiff
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3
 - package-ecosystem: npm
   directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3


### PR DESCRIPTION
In response to recent ecosystem attacks on dependencies, we need to add a cooldown period to Dependabot, so Dependabot waits a few days after a version is published before raising a PR. This gives the community time to flag compromised or broken releases.

I’ve added an exclusion for GDS-managed gems, as we have more control over releases.

This does not affect critical security patches. These will still be raised by Dependabot without delay.