### PR TITLE
CM-929: Fix time period date range error presentation

### DIFF
--- a/app/components/edition/details/fields/date_time_component.html.erb
+++ b/app/components/edition/details/fields/date_time_component.html.erb
@@ -3,6 +3,7 @@
 </legend>
 
 <%= render("components/datetime_fields", {
+  id: id,
   heading_size: "s",
   field_name: field_name,
   prefix: name_prefix,

--- a/app/components/edition/details/fields/date_time_component.html.erb
+++ b/app/components/edition/details/fields/date_time_component.html.erb
@@ -9,7 +9,7 @@
   date_heading: "Date",
   date_hint: "For example, 01 08 2025",
   time_hint: "For example, 09:30 or 19:30",
-  error_items: [],
+  error_items: error_items,
   year: {
     value: date_time&.year,
     id: id_for(:year),

--- a/app/components/edition/details/fields/date_time_component.rb
+++ b/app/components/edition/details/fields/date_time_component.rb
@@ -11,7 +11,7 @@ class Edition::Details::Fields::DateTimeComponent < ViewComponent::Base
 
   attr_reader :context, :field_name, :name_prefix, :block_type, :date_time
 
-  delegate :error_items, to: :context
+  delegate :error_items, :id, to: :context
 
   def id_for(field)
     "#{field_name}_#{field}"

--- a/app/components/edition/details/fields/date_time_component.rb
+++ b/app/components/edition/details/fields/date_time_component.rb
@@ -11,6 +11,8 @@ class Edition::Details::Fields::DateTimeComponent < ViewComponent::Base
 
   attr_reader :context, :field_name, :name_prefix, :block_type, :date_time
 
+  delegate :error_items, to: :context
+
   def id_for(field)
     "#{field_name}_#{field}"
   end

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -177,11 +177,14 @@ Then("the time period's date range block should not be shown") do
 end
 
 Then("I should see an error message telling me that the end date cannot be before the start date") do
-  expect(page).to have_selector(
-    "a[href='#edition_details_date_range_end']",
-    text: I18n.t("activerecord.errors.models.edition.minimum",
-                 attribute: "End",
-                 minimum_date: "Start"),
+  message = I18n.t(
+    "activerecord.errors.models.edition.minimum",
+    attribute: "End",
+    minimum_date: "Start",
+  )
+  has_error_message_linking_to_field_group(
+    message: message,
+    field_group_id: "#edition_details_date_range_end",
   )
 end
 
@@ -224,9 +227,19 @@ When("I edit the draft time period entering the invalid value of 30 Feb") do
 end
 
 Then("I should see an error message telling me that the date range field is invalid") do
-  expect(page).to have_content("Start is invalid")
+  has_error_message_linking_to_field_group(
+    message: "Start is invalid",
+    field_group_id: "#edition_details_date_range_start",
+  )
 end
 
 Then("the time period date range fields should be populated with the invalid values submitted") do
   time_period.should_see_raw_time_period_values_in_form(raw_values: time_period.invalid_date_raw_values, page: page)
+end
+
+def has_error_message_linking_to_field_group(message:, field_group_id:)
+  expect(page).to have_selector(
+    "a[href='#{field_group_id}']",
+    text: message,
+  )
 end

--- a/spec/components/edition/details/fields/date_time_component_spec.rb
+++ b/spec/components/edition/details/fields/date_time_component_spec.rb
@@ -136,6 +136,18 @@ RSpec.describe Edition::Details::Fields::DateTimeComponent, type: :component do
     end
   end
 
+  describe "when there is a validation error on the field" do
+    let(:edition) do
+      build(:edition, :time_period, details:).tap do |e|
+        e.errors.add(:details_date_range_start, "Start is invalid")
+      end
+    end
+
+    it "applies error styling to the datetime fields wrapper" do
+      expect(page).to have_css(".app-c-datetime-fields.govuk-form-group--error")
+    end
+  end
+
   describe "when re-rendering after validation failure" do
     describe "with an invalid date (e.g., Feb 30)" do
       let(:context) do

--- a/spec/components/edition/details/fields/date_time_component_spec.rb
+++ b/spec/components/edition/details/fields/date_time_component_spec.rb
@@ -146,6 +146,10 @@ RSpec.describe Edition::Details::Fields::DateTimeComponent, type: :component do
     it "applies error styling to the datetime fields wrapper" do
       expect(page).to have_css(".app-c-datetime-fields.govuk-form-group--error")
     end
+
+    it "has an id matching the error summary link target" do
+      expect(page).to have_css(".app-c-datetime-fields#edition_details_date_range_start")
+    end
   end
 
   describe "when re-rendering after validation failure" do


### PR DESCRIPTION
See Jira [CM-929](https://gov-uk.atlassian.net/browse/CM-929)

In this PR we improve the presentation of TimePeriod#date_range validation errors so that:

1. the offending field groups are highlighted
2. the error messages in the summary link to the corresponding field groups

<img width="2217" height="1980" alt="error_links_and_styles" src="https://github.com/user-attachments/assets/fe94d1de-a5df-4380-8176-eed69bb5c9b0" />


[CM-929]: https://gov-uk.atlassian.net/browse/CM-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ