### PR TITLE
(CM-930) Add a prototype for a snippets view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,8 @@ $govuk-page-width: 1140px;
 @import "views/content_block_manager_show";
 @import "views/editions/preview";
 
+@import "../../../engines/block_preview/app/assets/stylesheets/application";
+
 .app-js-only {
   display: none;
 }

--- a/app/public/lib/public/services.rb
+++ b/app/public/lib/public/services.rb
@@ -7,6 +7,14 @@ module Public::Services
     @publishing_api ||= publishing_api_client_with_timeout(20)
   end
 
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
+  end
+
+  def self.draft_content_store
+    @draft_content_store ||= GdsApi::ContentStore.new(Plek.find("draft-content-store"))
+  end
+
   def self.publishing_api_client_with_timeout(timeout)
     GdsApi::PublishingApi.new(
       Plek.find("publishing-api"),

--- a/config/features.rb
+++ b/config/features.rb
@@ -30,4 +30,8 @@ Flipflop.configure do
   feature :ga4_form_tracking,
           description: "Add GA4 form tracking to Content Block Manager",
           default: ContentBlockManager.integration_or_staging? || !Rails.env.production?
+
+  feature :show_snippets,
+          description: "Show snippets in Content Block preview",
+          default: ContentBlockManager.integration_or_staging? || !Rails.env.production?
 end

--- a/engines/block_preview/app/assets/stylesheets/application.scss
+++ b/engines/block_preview/app/assets/stylesheets/application.scss
@@ -1,0 +1,1 @@
+@import "components/snippets";

--- a/engines/block_preview/app/assets/stylesheets/components/snippets.scss
+++ b/engines/block_preview/app/assets/stylesheets/components/snippets.scss
@@ -1,0 +1,12 @@
+.result-wrapper {
+  padding: govuk-spacing(5);
+  background-color: govuk-colour("light-grey");
+}
+
+.result {
+  border: 1px solid govuk-colour("black");
+  margin-bottom: govuk-spacing(7);
+  padding: govuk-spacing(5);
+  color: govuk-colour("black");
+  background-color: govuk-colour("white");
+}

--- a/engines/block_preview/app/components/block_preview/tabs_component.html.erb
+++ b/engines/block_preview/app/components/block_preview/tabs_component.html.erb
@@ -1,0 +1,21 @@
+<%= render "govuk_publishing_components/components/secondary_navigation", {
+  aria_label: "Preview navigation",
+  items: [
+    {
+      label: "Preview instances (#{snippet_count})",
+      current: current_tab != "preview",
+      href: url_for_tab("instances"),
+      data_attributes: {
+        gtm: "tab",
+      },
+    },
+    {
+      label: "Preview document",
+      current: current_tab == "preview",
+      href: url_for_tab("preview"),
+      data_attributes: {
+        gtm: "tab",
+      },
+    },
+  ],
+} %>

--- a/engines/block_preview/app/components/block_preview/tabs_component.rb
+++ b/engines/block_preview/app/components/block_preview/tabs_component.rb
@@ -1,0 +1,24 @@
+class BlockPreview::TabsComponent < ViewComponent::Base
+  include BlockPreview::Engine.routes.url_helpers
+
+  def initialize(snippet_count:, current_tab:, block:, preview_content:)
+    @snippet_count = snippet_count
+    @current_tab = current_tab
+    @block = block
+    @preview_content = preview_content
+  end
+
+private
+
+  attr_reader :snippet_count, :current_tab, :block, :preview_content
+
+  def url_for_tab(tab)
+    host_content_preview_path(
+      edition_id: block.id,
+      host_content_id: preview_content.content_id,
+      locale: preview_content.locale,
+      state: preview_content.state,
+      tab:,
+    )
+  end
+end

--- a/engines/block_preview/app/controllers/block_preview/preview_controller.rb
+++ b/engines/block_preview/app/controllers/block_preview/preview_controller.rb
@@ -17,6 +17,7 @@ class BlockPreview::PreviewController < BlockPreview::ApplicationController
         host_content_id,
         state: params[:state].presence || "published",
         block: @block,
+        locale: params[:locale],
       )
 
       if @current_tab == "preview"

--- a/engines/block_preview/app/controllers/block_preview/preview_controller.rb
+++ b/engines/block_preview/app/controllers/block_preview/preview_controller.rb
@@ -13,7 +13,11 @@ class BlockPreview::PreviewController < BlockPreview::ApplicationController
     )
     if Flipflop.enabled?(:show_snippets)
       @current_tab = params[:tab]
-      @snippets = BlockPreview::Snippet.from_html(@preview_content.html)
+      @snippets = BlockPreview::Snippet.for_content_id(
+        host_content_id,
+        state: params[:state].presence || "published",
+        block: @block,
+      )
 
       if @current_tab == "preview"
         render "show"

--- a/engines/block_preview/app/controllers/block_preview/preview_controller.rb
+++ b/engines/block_preview/app/controllers/block_preview/preview_controller.rb
@@ -11,6 +11,18 @@ class BlockPreview::PreviewController < BlockPreview::ApplicationController
       locale: params[:locale],
       state: params[:state].presence || "published",
     )
+    if Flipflop.enabled?(:show_snippets)
+      @current_tab = params[:tab]
+      @snippets = BlockPreview::Snippet.from_html(@preview_content.html)
+
+      if @current_tab == "preview"
+        render "show"
+      else
+        render "show_with_snippets"
+      end
+    else
+      render "show"
+    end
   end
 
   def form_handler

--- a/engines/block_preview/app/model/block_preview/content_diff.rb
+++ b/engines/block_preview/app/model/block_preview/content_diff.rb
@@ -1,6 +1,6 @@
 class BlockPreview::ContentDiff
   def initialize(html, block)
-    @before = html.at_css('[data-module="govspeak"]')
+    @before = html
     @block = block
   end
 
@@ -12,8 +12,10 @@ private
 
   def diff_fragment
     @diff_fragment ||= begin
-      fragment = Nokogiri::HTML.fragment(Nokodiff.diff(before, after))
-      fragment.children.first.add_class("compare-editions")
+      fragment = Nokogiri::HTML.fragment(Nokodiff.diff(before.to_s, after.to_s))
+      wrapped = Nokogiri::HTML.fragment("<div class='compare-editions'></div>")
+      wrapped.at_css("div").add_child(fragment)
+      wrapped.to_html
     end
   end
 

--- a/engines/block_preview/app/model/block_preview/preview_content.rb
+++ b/engines/block_preview/app/model/block_preview/preview_content.rb
@@ -2,7 +2,7 @@ module BlockPreview
   class PreviewContent
     VALID_STATES = %w[published draft].freeze
 
-    attr_reader :state
+    attr_reader :state, :content_id, :block, :base_path, :locale
 
     def initialize(content_id:, block:, base_path: nil, locale: "en", state: "published")
       @content_id = content_id
@@ -32,8 +32,6 @@ module BlockPreview
     end
 
   private
-
-    attr_reader :content_id, :block, :base_path, :locale
 
     def validated_state(state)
       return state if VALID_STATES.include?(state)

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -91,7 +91,7 @@ module BlockPreview
     end
 
     def update_local_link_paths(nokogiri_html)
-      url = host_content_preview_path(edition_id: block.id, host_content_id: content_id, locale:, state:)
+      url = host_content_preview_path(edition_id: block.id, host_content_id: content_id, locale:, state:, tab: "preview")
       nokogiri_html.css("a").each do |link|
         next if link[:href].start_with?("//") || link[:href].start_with?("http")
 
@@ -103,7 +103,7 @@ module BlockPreview
     end
 
     def update_local_form_actions(nokogiri_html, scheme, host)
-      url = host_content_preview_form_handler_path(edition_id: block.id, host_content_id: content_id, locale:)
+      url = host_content_preview_form_handler_path(edition_id: block.id, host_content_id: content_id, locale:, tab: "preview")
       nokogiri_html.css("main form").each do |form|
         form[:action] = "#{url}&url=#{scheme}://#{host}#{form[:action]}&method=#{form[:method]}"
         form[:target] = "_parent"

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -143,7 +143,7 @@ module BlockPreview
     def update_preview_with_diff(nokogiri_html)
       nokogiri_html.at_css("[data-module=\"govspeak\"]")
                    .replace(
-                     BlockPreview::ContentDiff.new(nokogiri_html, block).to_s,
+                     BlockPreview::ContentDiff.new(nokogiri_html.at_css('[data-module="govspeak"]'), block).to_s,
                    )
 
       nokogiri_html

--- a/engines/block_preview/app/model/block_preview/snippet.rb
+++ b/engines/block_preview/app/model/block_preview/snippet.rb
@@ -96,9 +96,13 @@ private
       parent = table_cell_ancestor.ancestors("table").first || table_cell_ancestor
     end
 
-    # If there is no previous element (for example, if the parent is contained within
-    # a div), we keep trying until the parent element has a previous element
-    parent = parent.parent while parent.previous_element.nil?
+    # If there is no previous element, walk up the tree until we find one.
+    # Stop before leaving element nodes to avoid calling `parent` on a document.
+    while parent.previous_element.nil?
+      break unless parent.respond_to?(:parent) && parent.parent&.element?
+
+      parent = parent.parent
+    end
 
     parent
   end

--- a/engines/block_preview/app/model/block_preview/snippet.rb
+++ b/engines/block_preview/app/model/block_preview/snippet.rb
@@ -1,0 +1,82 @@
+class BlockPreview::Snippet
+  class << self
+    def from_html(html)
+      doc = Nokogiri::HTML(html)
+      shown_element_paths = []
+
+      doc.css(".content-block").map { |block|
+        snippet = new(doc, block)
+        next if shown_element_paths.include?(snippet.context_parent.path)
+
+        preview_elements = snippet.context_elements.drop_while do |element|
+          shown_element_paths.include?(element.path)
+        end
+
+        next if preview_elements.empty?
+
+        shown_element_paths.concat(preview_elements.map(&:path))
+
+        new(doc, block, preview_elements:)
+      }.compact
+    end
+  end
+
+  def initialize(doc, block, preview_elements: nil)
+    @doc = doc
+    @block = block
+    @preview_elements = preview_elements
+  end
+
+  def to_html
+    context_elements.map(&:to_s).join("\n")
+  end
+
+  def context_parent_html
+    context_parent.to_s
+  end
+
+  def context_parent
+    get_parent
+  end
+
+  def context_elements
+    @preview_elements || default_preview_elements
+  end
+
+private
+
+  attr_reader :doc, :block
+
+  def default_preview_elements
+    parent = context_parent
+
+    [
+      parent.previous_element&.previous_element,
+      parent.previous_element,
+      parent,
+      parent.next_element,
+      parent.next_element&.next_element,
+    ].compact
+  end
+
+  def get_parent
+    parent = block.parent
+    list_item_ancestor = block.ancestors("li").first
+    table_cell_ancestor = block.ancestors("td").first
+
+    # If the block is within a list item or a table, we want to ensure
+    # the containing list/table is preserved, so we can show the surrounding
+    # HTML
+    if list_item_ancestor
+      parent = list_item_ancestor.ancestors("ul, ol").first || list_item_ancestor
+    elsif table_cell_ancestor
+      parent = table_cell_ancestor.ancestors("table").first || table_cell_ancestor
+    end
+
+    # If there is no previous element (for example, if the parent is contained within
+    # a div), we keep trying until the parent element has a previous element
+    parent = parent.parent while parent.previous_element.nil?
+
+    parent
+  end
+end

--- a/engines/block_preview/app/model/block_preview/snippet.rb
+++ b/engines/block_preview/app/model/block_preview/snippet.rb
@@ -1,16 +1,19 @@
 class BlockPreview::Snippet
   class << self
     def for_content_id(content_id, state:, block:)
-      diff = BlockPreview::ContentDiff.new(html_snippet(content_id, state), block)
-      from_html(diff.to_s)
+      diff = BlockPreview::ContentDiff.new(
+        html_snippet(content_id, state),
+        block,
+      )
+      from_html(diff.to_s, block)
     end
 
-    def from_html(html)
+    def from_html(html, block)
       doc = Nokogiri::HTML(html)
       shown_element_paths = []
 
-      doc.css(".content-block").map { |block|
-        snippet = new(doc, block)
+      doc.css(%([data-content-id="#{block.content_id}"])).map { |content_block|
+        snippet = new(doc, content_block)
         next if shown_element_paths.include?(snippet.context_parent.path)
 
         preview_elements = snippet.context_elements.drop_while do |element|
@@ -21,7 +24,7 @@ class BlockPreview::Snippet
 
         shown_element_paths.concat(preview_elements.map(&:path))
 
-        new(doc, block, preview_elements:)
+        new(doc, content_block, preview_elements:)
       }.compact
     end
 

--- a/engines/block_preview/app/model/block_preview/snippet.rb
+++ b/engines/block_preview/app/model/block_preview/snippet.rb
@@ -1,8 +1,8 @@
 class BlockPreview::Snippet
   class << self
-    def for_content_id(content_id, state:, block:)
+    def for_content_id(content_id, state:, block:, locale:)
       diff = BlockPreview::ContentDiff.new(
-        html_snippet(content_id, state),
+        html_snippet(content_id, state, locale),
         block,
       )
       from_html(diff.to_s, block)
@@ -30,8 +30,8 @@ class BlockPreview::Snippet
 
   private
 
-    def html_snippet(content_id, state)
-      publishing_api_response = Public::Services.publishing_api.get_content(content_id)
+    def html_snippet(content_id, state, locale)
+      publishing_api_response = Public::Services.publishing_api.get_content(content_id, locale:)
       content_store = state == "published" ? Public::Services.content_store : Public::Services.draft_content_store
       content_store_response = content_store.content_item(publishing_api_response["base_path"])
       html = if %w[guide travel_advice].include?(content_store_response["document_type"])

--- a/engines/block_preview/app/model/block_preview/snippet.rb
+++ b/engines/block_preview/app/model/block_preview/snippet.rb
@@ -1,5 +1,10 @@
 class BlockPreview::Snippet
   class << self
+    def for_content_id(content_id, state:, block:)
+      diff = BlockPreview::ContentDiff.new(html_snippet(content_id, state), block)
+      from_html(diff.to_s)
+    end
+
     def from_html(html)
       doc = Nokogiri::HTML(html)
       shown_element_paths = []
@@ -18,6 +23,21 @@ class BlockPreview::Snippet
 
         new(doc, block, preview_elements:)
       }.compact
+    end
+
+  private
+
+    def html_snippet(content_id, state)
+      publishing_api_response = Public::Services.publishing_api.get_content(content_id)
+      content_store = state == "published" ? Public::Services.content_store : Public::Services.draft_content_store
+      content_store_response = content_store.content_item(publishing_api_response["base_path"])
+      html = if %w[guide travel_advice].include?(content_store_response["document_type"])
+               content_store_response["details"]["parts"].map { |part| part["body"] }.join("\n")
+             else
+               content_store_response["details"]["body"]
+             end
+
+      Nokogiri::HTML.fragment(html)
     end
   end
 

--- a/engines/block_preview/app/views/block_preview/preview/show_with_snippets.html.erb
+++ b/engines/block_preview/app/views/block_preview/preview/show_with_snippets.html.erb
@@ -3,31 +3,29 @@
 <% content_for :title, @preview_content.title %>
 <% content_for :title_margin_bottom, 1 %>
 
-<% content_for :head do %>
-  <%= javascript_include_tag "host-content-iframe" %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-bottom-0">
     <%= render(BlockPreview::PreviewDetailsComponent.new(
-          block: @block,
-          preview_content: @preview_content)) %>
+      block: @block,
+      preview_content: @preview_content)) %>
   </div>
 </div>
 <hr class="govuk-section-break govuk-!-margin-bottom-8 govuk-section-break--visible">
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% if Flipflop.enabled?(:show_snippets) %>
-      <%= render BlockPreview::TabsComponent.new(
-        current_tab: @current_tab,
-        snippet_count: @snippets.count,
-        block: @block,
-        preview_content: @preview_content,
-      ) %>
-    <% end %>
+    <%= render BlockPreview::TabsComponent.new(
+      current_tab: @current_tab,
+      snippet_count: @snippets.count,
+      block: @block,
+      preview_content: @preview_content,
+    ) %>
 
-    <%= turbo_frame_tag "preview_frame_#{@block.id}" do %>
-      <%= render partial: "iframe" %>
-    <% end %>
+    <div class="result-wrapper">
+      <% @snippets.each do |snippet| %>
+        <div class="result govspeak compare-editions">
+          <%= snippet.to_html.html_safe %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/engines/block_preview/features/host_document_preview.feature
+++ b/engines/block_preview/features/host_document_preview.feature
@@ -4,6 +4,7 @@ Feature: Host document preview
     And the organisation "Ministry of Example" exists
     And a pension content block has been created
     And dependent content exists for a content block
+    And the show_snippets feature flag is not turned on
 
   @javascript
   Scenario: GDS editor can preview a host document

--- a/engines/block_preview/spec/components/block_preview/tabs_spec.rb
+++ b/engines/block_preview/spec/components/block_preview/tabs_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe BlockPreview::TabsComponent, type: :component do
+  include BlockPreview::Engine.routes.url_helpers
+
+  let(:block) { build_stubbed(:content_block) }
+  let(:preview_content) do
+    double(
+      :preview_content,
+      content_id: SecureRandom.uuid,
+      locale: "en",
+      state: "draft",
+    )
+  end
+
+  it "renders links for the instances and preview tabs" do
+    render_inline(
+      described_class.new(
+        snippet_count: 3,
+        current_tab: "instances",
+        block:,
+        preview_content:,
+      ),
+    )
+
+    instances_link = page.find("a", text: "Preview instances (3)")
+    preview_link = page.find("a", text: "Preview document")
+
+    expect(instances_link[:href]).to eq(
+      host_content_preview_path(
+        edition_id: block.id,
+        host_content_id: preview_content.content_id,
+        locale: preview_content.locale,
+        state: preview_content.state,
+        tab: "instances",
+      ),
+    )
+
+    expect(preview_link[:href]).to eq(
+      host_content_preview_path(
+        edition_id: block.id,
+        host_content_id: preview_content.content_id,
+        locale: preview_content.locale,
+        state: preview_content.state,
+        tab: "preview",
+      ),
+    )
+  end
+
+  it "marks the preview tab as current when current_tab is preview" do
+    render_inline(
+      described_class.new(
+        snippet_count: 1,
+        current_tab: "preview",
+        block:,
+        preview_content:,
+      ),
+    )
+
+    expect(page).to have_css("li.gem-c-secondary-navigation__list-item--current", text: "Preview document")
+    expect(page).to have_css("li", text: "Preview instances (1)")
+    expect(page).to have_no_css("li.gem-c-secondary-navigation__list-item--current", text: "Preview instances (1)")
+  end
+end

--- a/engines/block_preview/spec/requests/preview_controller_spec.rb
+++ b/engines/block_preview/spec/requests/preview_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe BlockPreview::PreviewController, type: :request do
   before do
     allow(ContentBlock).to receive(:from_edition_id).and_return(block)
     allow(BlockPreview::PreviewContent).to receive(:new).and_return(mock_preview_content)
+    allow(Flipflop).to receive(:enabled?).with(:show_snippets).and_return(false)
   end
 
   describe "GET #show" do

--- a/engines/block_preview/spec/unit/app/controllers/preview_controller_spec.rb
+++ b/engines/block_preview/spec/unit/app/controllers/preview_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe BlockPreview::PreviewController, type: :controller do
     before do
       allow(ContentBlock).to receive(:from_edition_id).and_return(mock_block)
       allow(BlockPreview::PreviewContent).to receive(:new).and_return(mock_preview_content)
+      allow(Flipflop).to receive(:enabled?).with(:show_snippets).and_return(false)
 
       get :show, params: {
         edition_id: edition_id,
@@ -68,6 +69,79 @@ RSpec.describe BlockPreview::PreviewController, type: :controller do
           locale: locale,
           state: "published",
         )
+      end
+    end
+
+    context "when the show_snippets feature flag is enabled" do
+      let(:mock_snippets) { [instance_double(BlockPreview::Snippet)] }
+
+      before do
+        allow(Flipflop).to receive(:enabled?).with(:show_snippets).and_return(true)
+        allow(mock_preview_content).to receive(:html).and_return("<p><span class='content-block'>value</span></p>")
+        allow(BlockPreview::Snippet).to receive(:from_html).and_return(mock_snippets)
+      end
+
+      context "when tab is preview" do
+        before do
+          get :show, params: {
+            edition_id: edition_id,
+            host_content_id: host_content_id,
+            base_path: base_path,
+            locale: locale,
+            state: state,
+            tab: "preview",
+          }
+        end
+
+        it "extracts snippets from the preview html" do
+          expect(BlockPreview::Snippet).to have_received(:from_html).with(mock_preview_content.html)
+        end
+
+        it "assigns the current tab" do
+          expect(assigns(:current_tab)).to eq("preview")
+        end
+
+        it "assigns snippets" do
+          expect(assigns(:snippets)).to eq(mock_snippets)
+        end
+
+        it "renders the preview template" do
+          expect(response).to render_template("show")
+        end
+      end
+
+      context "when tab is not preview" do
+        before do
+          get :show, params: {
+            edition_id: edition_id,
+            host_content_id: host_content_id,
+            base_path: base_path,
+            locale: locale,
+            state: state,
+            tab: "instances",
+          }
+        end
+
+        it "renders the snippet list template" do
+          expect(response).to render_template("show_with_snippets")
+        end
+      end
+
+      context "when tab is omitted" do
+        before do
+          get :show, params: {
+            edition_id: edition_id,
+            host_content_id: host_content_id,
+            base_path: base_path,
+            locale: locale,
+            state: state,
+          }
+        end
+
+        it "defaults to rendering the snippet list template" do
+          expect(assigns(:current_tab)).to be_nil
+          expect(response).to render_template("show_with_snippets")
+        end
       end
     end
   end

--- a/engines/block_preview/spec/unit/app/controllers/preview_controller_spec.rb
+++ b/engines/block_preview/spec/unit/app/controllers/preview_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe BlockPreview::PreviewController, type: :controller do
       before do
         allow(Flipflop).to receive(:enabled?).with(:show_snippets).and_return(true)
         allow(mock_preview_content).to receive(:html).and_return("<p><span class='content-block'>value</span></p>")
-        allow(BlockPreview::Snippet).to receive(:from_html).and_return(mock_snippets)
+        allow(BlockPreview::Snippet).to receive(:for_content_id).and_return(mock_snippets)
       end
 
       context "when tab is preview" do
@@ -94,7 +94,7 @@ RSpec.describe BlockPreview::PreviewController, type: :controller do
         end
 
         it "extracts snippets from the preview html" do
-          expect(BlockPreview::Snippet).to have_received(:from_html).with(mock_preview_content.html)
+          expect(BlockPreview::Snippet).to have_received(:for_content_id).with(host_content_id, state: state, block: mock_block)
         end
 
         it "assigns the current tab" do

--- a/engines/block_preview/spec/unit/app/controllers/preview_controller_spec.rb
+++ b/engines/block_preview/spec/unit/app/controllers/preview_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe BlockPreview::PreviewController, type: :controller do
         end
 
         it "extracts snippets from the preview html" do
-          expect(BlockPreview::Snippet).to have_received(:for_content_id).with(host_content_id, state: state, block: mock_block)
+          expect(BlockPreview::Snippet).to have_received(:for_content_id).with(host_content_id, state: state, block: mock_block, locale: locale)
         end
 
         it "assigns the current tab" do

--- a/engines/block_preview/spec/unit/app/models/content_diff_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/content_diff_spec.rb
@@ -8,14 +8,8 @@ RSpec.describe BlockPreview::ContentDiff do
     context "when govspeak includes a matching embedded content block" do
       let(:html) do
         Nokogiri::HTML.parse(<<~HTML)
-          <html>
-            <body>
-              <div data-module="govspeak">
-                <p>Before content</p>
-                <span data-content-id="#{content_id}" data-embed-code="embed-1">Old block</span>
-              </div>
-            </body>
-          </html>
+          <p>Before content</p>
+          <span data-content-id="#{content_id}" data-embed-code="embed-1">Old block</span>
         HTML
       end
 
@@ -40,14 +34,8 @@ RSpec.describe BlockPreview::ContentDiff do
       let(:other_content_id) { SecureRandom.uuid }
       let(:html) do
         Nokogiri::HTML.parse(<<~HTML)
-          <html>
-            <body>
-              <div data-module="govspeak">
-                <span data-content-id="#{content_id}" data-embed-code="embed-1">Old matching block</span>
-                <span data-content-id="#{other_content_id}" data-embed-code="embed-2">Old non-matching block</span>
-              </div>
-            </body>
-          </html>
+          <span data-content-id="#{content_id}" data-embed-code="embed-1">Old matching block</span>
+          <span data-content-id="#{other_content_id}" data-embed-code="embed-2">Old non-matching block</span>
         HTML
       end
 
@@ -71,14 +59,8 @@ RSpec.describe BlockPreview::ContentDiff do
     context "when multiple wrappers match the target content id" do
       let(:html) do
         Nokogiri::HTML.parse(<<~HTML)
-          <html>
-            <body>
-              <div data-module="govspeak">
-                <span data-content-id="#{content_id}" data-embed-code="embed-1">Old block 1</span>
-                <span data-content-id="#{content_id}" data-embed-code="embed-2">Old block 2</span>
-              </div>
-            </body>
-          </html>
+          <span data-content-id="#{content_id}" data-embed-code="embed-1">Old block 1</span>
+          <span data-content-id="#{content_id}" data-embed-code="embed-2">Old block 2</span>
         HTML
       end
 
@@ -98,13 +80,7 @@ RSpec.describe BlockPreview::ContentDiff do
     context "when a matching wrapper has no embed code" do
       let(:html) do
         Nokogiri::HTML.parse(<<~HTML)
-          <html>
-            <body>
-              <div data-module="govspeak">
-                <span data-content-id="#{content_id}">Old block</span>
-              </div>
-            </body>
-          </html>
+          <span data-content-id="#{content_id}">Old block</span>
         HTML
       end
 
@@ -117,22 +93,6 @@ RSpec.describe BlockPreview::ContentDiff do
 
         expect(block).to have_received(:render).with(nil)
         expect(output).to include("compare-editions")
-      end
-    end
-
-    context "when the source html has no govspeak node" do
-      let(:html) do
-        Nokogiri::HTML.parse(<<~HTML)
-          <html>
-            <body>
-              <p>No govspeak content here</p>
-            </body>
-          </html>
-        HTML
-      end
-
-      it "raises an error when generating the diff" do
-        expect { content_diff.to_s }.to raise_error(NoMethodError)
       end
     end
   end

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -213,6 +213,10 @@ RSpec.describe BlockPreview::PreviewHtml do
           expect(internal_link_query_hash["locale"]).to eq("en")
         end
 
+        it "represents the correct tab with tab param" do
+          expect(internal_link_query_hash["tab"]).to eq("preview")
+        end
+
         it "represents the target base path with url param" do
           expect(internal_link_query_hash["base_path"]).to eq("/foo")
         end
@@ -271,6 +275,7 @@ RSpec.describe BlockPreview::PreviewHtml do
         edition_id: block_to_preview.id,
         host_content_id: host_content_id,
         locale: "en",
+        tab: "preview",
       )
       expected_url = "#{Plek.website_root}/foo"
       expected_action = "#{form_handler_path}&url=#{expected_url}&method=get"

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -97,6 +97,10 @@ RSpec.describe BlockPreview::PreviewHtml do
   end
 
   it "returns the preview html" do
+    nokogiri_spy = double("Nokogiri::HTML::DocumentFragment", replace: "")
+    allow_any_instance_of(Nokogiri::HTML::Document).to receive(:at_css).and_call_original
+    allow_any_instance_of(Nokogiri::HTML::Document).to receive(:at_css).with('[data-module="govspeak"]').and_return(nokogiri_spy)
+
     actual_content = BlockPreview::PreviewHtml.new(
       content_id: host_content_id,
       block: block_to_preview,
@@ -110,7 +114,7 @@ RSpec.describe BlockPreview::PreviewHtml do
 
     expect(parsed_content.at_css("body.gem-c-layout-for-public--draft")).to be_present
     expect(BlockPreview::ContentDiff).to have_received(:new).with(
-      anything,
+      nokogiri_spy,
       block_to_preview,
     )
     expect(content_diff_spy).to have_received(:to_s)

--- a/engines/block_preview/spec/unit/app/models/snippet_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/snippet_spec.rb
@@ -1,0 +1,218 @@
+RSpec.describe BlockPreview::Snippet do
+  describe ".from_html" do
+    it "returns an empty array when there are no content blocks" do
+      html = <<~HTML
+        <main>
+          <p>No embeds here</p>
+        </main>
+      HTML
+
+      expect(described_class.from_html(html)).to eq([])
+    end
+
+    it "returns one snippet per content block when they are separate" do
+      html = <<~HTML
+        <main>
+          <p>Lead paragraph</p>
+          <p><span class="content-block">A</span></p>
+          <p>Gap one</p>
+          <p>Gap two</p>
+          <p>Gap three</p>
+          <p><span class="content-block">B</span></p>
+          <p>Tail paragraph</p>
+        </main>
+      HTML
+
+      snippets = described_class.from_html(html)
+
+      expect(snippets.count).to eq(2)
+      expect(snippets.map(&:to_html).join("\n")).to include("A")
+      expect(snippets.map(&:to_html).join("\n")).to include("B")
+    end
+
+    it "de-duplicates snippets when multiple content blocks share the same parent" do
+      html = <<~HTML
+        <main>
+          <p>Lead paragraph</p>
+          <p>
+            <span class="content-block">A</span>
+            <span class="content-block">B</span>
+          </p>
+          <p>Tail paragraph</p>
+        </main>
+      HTML
+
+      snippets = described_class.from_html(html)
+
+      expect(snippets.count).to eq(1)
+      expect(snippets.first.to_html).to include("A")
+      expect(snippets.first.to_html).to include("B")
+    end
+
+    it "de-duplicates a later snippet when its list is already included in an earlier snippet" do
+      html = <<~HTML
+        <main>
+          <p>Lead paragraph</p>
+          <div class="diff">
+            <ins>
+              The full rate is <span class="content-block">£122.55</span>
+            </ins>
+          </div>
+          <ul>
+            <li>Unchanged item</li>
+            <li>
+              <div class="diff">
+                <ins>
+                  Something about the pension rate <span class="content-block">£122.55</span> in a list item
+                </ins>
+              </div>
+            </li>
+            <li>Another unchanged item</li>
+          </ul>
+          <p>Tail paragraph</p>
+        </main>
+      HTML
+
+      snippets = described_class.from_html(html)
+
+      expect(snippets.count).to eq(1)
+      expect(snippets.first.to_html).to include("<ul>")
+      expect(snippets.first.to_html.scan("<ul>").count).to eq(1)
+    end
+
+    it "keeps later snippets whose parent is not already present in an earlier snippet" do
+      html = <<~HTML
+        <main>
+          <p>Your State Pension amount depends on your National Insurance record.</p>
+          <p>Check your State Pension forecast.</p>
+          <div class="diff">
+            <del>
+              <p>The full rate is <span class="content-block">£122.40</span>.</p>
+            </del>
+          </div>
+          <div class="diff">
+            <ins>
+              <p>The full rate is <span class="content-block">£122.55</span>.</p>
+            </ins>
+          </div>
+          <ul>
+            <li>if you were contracted out before 2016</li>
+            <li>
+              <div class="diff">
+                <del>Something about the pension rate <span class="content-block">£122.40</span> in a list item</del>
+              </div>
+            </li>
+            <li>
+              <div class="diff">
+                <ins>Something about the pension rate <span class="content-block">£122.55</span> in a list item</ins>
+              </div>
+            </li>
+          </ul>
+          <p>Find out what tax you might pay.</p>
+          <div class="diff">
+            <del>
+              <h2>If you’re getting less than <span class="content-block">£122.40</span> a week</h2>
+            </del>
+          </div>
+          <div class="diff">
+            <ins>
+              <h2>If you’re getting less than <span class="content-block">£122.55</span> a week</h2>
+            </ins>
+          </div>
+          <p>You might need more qualifying years.</p>
+        </main>
+      HTML
+
+      snippets = described_class.from_html(html)
+
+      expect(snippets.count).to eq(2)
+      expect(snippets.first.to_html).to include("<ul>")
+      expect(snippets.last.to_html).to include("If you’re getting less than")
+      expect(snippets.last.to_html).not_to include("Something about the pension rate")
+      expect(snippets.map(&:to_html).join("\n").scan("Something about the pension rate").count).to eq(2)
+    end
+  end
+
+  describe "#to_html" do
+    let(:doc) { Nokogiri::HTML(html) }
+    let(:block) { doc.at_css(css_selector) }
+    let(:snippet) { described_class.new(doc, block) }
+
+    context "when the content block is in a paragraph" do
+      let(:css_selector) { ".content-block" }
+      let(:html) do
+        <<~HTML
+          <main>
+            <h2>Heading</h2>
+            <p>Previous</p>
+            <p><span class="content-block">Embed</span></p>
+            <p>Next</p>
+            <p>After next</p>
+          </main>
+        HTML
+      end
+
+      it "returns a five element window around the parent" do
+        output = snippet.to_html
+
+        expect(output).to include("<h2>Heading</h2>")
+        expect(output).to include("<p>Previous</p>")
+        expect(output).to include("<p><span class=\"content-block\">Embed</span></p>")
+        expect(output).to include("<p>Next</p>")
+        expect(output).to include("<p>After next</p>")
+      end
+    end
+
+    context "when the content block is inside a list item" do
+      let(:css_selector) { ".content-block" }
+      let(:html) do
+        <<~HTML
+          <main>
+            <p>Before list</p>
+            <ul>
+              <li>
+                <div class="diff">
+                  <ins><span class="content-block">Embed</span></ins>
+                </div>
+              </li>
+              <li>Other item</li>
+            </ul>
+            <p>After list</p>
+          </main>
+        HTML
+      end
+
+      it "uses the list container as the parent" do
+        output = snippet.to_html
+
+        expect(output).to include("<ul>")
+        expect(output).to include("<span class=\"content-block\">Embed</span>")
+        expect(output).to include("<li>Other item</li>")
+      end
+    end
+
+    context "when the content block is inside a table cell" do
+      let(:css_selector) { ".content-block" }
+      let(:html) do
+        <<~HTML
+          <main>
+            <p>Before table</p>
+            <table>
+              <tr>
+                <td><span class="content-block">Embed</span></td>
+              </tr>
+            </table>
+            <p>After table</p>
+          </main>
+        HTML
+      end
+
+      it "uses the table container as the parent" do
+        output = snippet.to_html
+
+        expect(output).to include("<table>")
+        expect(output).to include("<td><span class=\"content-block\">Embed</span></td>")
+      end
+    end
+  end
+end

--- a/engines/block_preview/spec/unit/app/models/snippet_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/snippet_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BlockPreview::Snippet do
       allow(Public::Services.publishing_api).to receive(:get_content)
         .with(content_id)
         .and_return(publishing_api_response)
-      allow(described_class).to receive(:from_html).with(diff_output).and_return(snippets)
+      allow(described_class).to receive(:from_html).with(diff_output, block).and_return(snippets)
       allow(BlockPreview::ContentDiff).to receive(:new).and_return(diff)
     end
 
@@ -60,6 +60,9 @@ RSpec.describe BlockPreview::Snippet do
   end
 
   describe ".from_html" do
+    let(:target_content_id) { "target-content-id" }
+    let(:target_block) { instance_double("ContentBlock", content_id: target_content_id) }
+
     it "returns an empty array when there are no content blocks" do
       html = <<~HTML
         <main>
@@ -67,23 +70,23 @@ RSpec.describe BlockPreview::Snippet do
         </main>
       HTML
 
-      expect(described_class.from_html(html)).to eq([])
+      expect(described_class.from_html(html, target_block)).to eq([])
     end
 
     it "returns one snippet per content block when they are separate" do
       html = <<~HTML
         <main>
           <p>Lead paragraph</p>
-          <p><span class="content-block">A</span></p>
+          <p><span data-content-id="target-content-id">A</span></p>
           <p>Gap one</p>
           <p>Gap two</p>
           <p>Gap three</p>
-          <p><span class="content-block">B</span></p>
+          <p><span data-content-id="target-content-id">B</span></p>
           <p>Tail paragraph</p>
         </main>
       HTML
 
-      snippets = described_class.from_html(html)
+      snippets = described_class.from_html(html, target_block)
 
       expect(snippets.count).to eq(2)
       expect(snippets.map(&:to_html).join("\n")).to include("A")
@@ -95,14 +98,14 @@ RSpec.describe BlockPreview::Snippet do
         <main>
           <p>Lead paragraph</p>
           <p>
-            <span class="content-block">A</span>
-            <span class="content-block">B</span>
+            <span data-content-id="target-content-id">A</span>
+            <span data-content-id="target-content-id">B</span>
           </p>
           <p>Tail paragraph</p>
         </main>
       HTML
 
-      snippets = described_class.from_html(html)
+      snippets = described_class.from_html(html, target_block)
 
       expect(snippets.count).to eq(1)
       expect(snippets.first.to_html).to include("A")
@@ -115,7 +118,7 @@ RSpec.describe BlockPreview::Snippet do
           <p>Lead paragraph</p>
           <div class="diff">
             <ins>
-              The full rate is <span class="content-block">£122.55</span>
+               The full rate is <span data-content-id="target-content-id">£122.55</span>
             </ins>
           </div>
           <ul>
@@ -123,7 +126,7 @@ RSpec.describe BlockPreview::Snippet do
             <li>
               <div class="diff">
                 <ins>
-                  Something about the pension rate <span class="content-block">£122.55</span> in a list item
+                   Something about the pension rate <span data-content-id="target-content-id">£122.55</span> in a list item
                 </ins>
               </div>
             </li>
@@ -133,7 +136,7 @@ RSpec.describe BlockPreview::Snippet do
         </main>
       HTML
 
-      snippets = described_class.from_html(html)
+      snippets = described_class.from_html(html, target_block)
 
       expect(snippets.count).to eq(1)
       expect(snippets.first.to_html).to include("<ul>")
@@ -147,43 +150,43 @@ RSpec.describe BlockPreview::Snippet do
           <p>Check your State Pension forecast.</p>
           <div class="diff">
             <del>
-              <p>The full rate is <span class="content-block">£122.40</span>.</p>
+               <p>The full rate is <span data-content-id="target-content-id">£122.40</span>.</p>
             </del>
           </div>
           <div class="diff">
             <ins>
-              <p>The full rate is <span class="content-block">£122.55</span>.</p>
+               <p>The full rate is <span data-content-id="target-content-id">£122.55</span>.</p>
             </ins>
           </div>
           <ul>
             <li>if you were contracted out before 2016</li>
             <li>
               <div class="diff">
-                <del>Something about the pension rate <span class="content-block">£122.40</span> in a list item</del>
+                 <del>Something about the pension rate <span data-content-id="target-content-id">£122.40</span> in a list item</del>
               </div>
             </li>
             <li>
               <div class="diff">
-                <ins>Something about the pension rate <span class="content-block">£122.55</span> in a list item</ins>
+                 <ins>Something about the pension rate <span data-content-id="target-content-id">£122.55</span> in a list item</ins>
               </div>
             </li>
           </ul>
           <p>Find out what tax you might pay.</p>
           <div class="diff">
             <del>
-              <h2>If you’re getting less than <span class="content-block">£122.40</span> a week</h2>
+               <h2>If you’re getting less than <span data-content-id="target-content-id">£122.40</span> a week</h2>
             </del>
           </div>
           <div class="diff">
             <ins>
-              <h2>If you’re getting less than <span class="content-block">£122.55</span> a week</h2>
+               <h2>If you’re getting less than <span data-content-id="target-content-id">£122.55</span> a week</h2>
             </ins>
           </div>
           <p>You might need more qualifying years.</p>
         </main>
       HTML
 
-      snippets = described_class.from_html(html)
+      snippets = described_class.from_html(html, target_block)
 
       expect(snippets.count).to eq(2)
       expect(snippets.first.to_html).to include("<ul>")

--- a/engines/block_preview/spec/unit/app/models/snippet_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/snippet_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BlockPreview::Snippet do
 
     before do
       allow(Public::Services.publishing_api).to receive(:get_content)
-        .with(content_id)
+        .with(content_id, locale: "en")
         .and_return(publishing_api_response)
       allow(described_class).to receive(:from_html).with(diff_output, block).and_return(snippets)
       allow(BlockPreview::ContentDiff).to receive(:new).and_return(diff)
@@ -32,7 +32,7 @@ RSpec.describe BlockPreview::Snippet do
         expect(received_block).to be(block)
       }.and_return(diff)
 
-      expect(described_class.for_content_id(content_id, state: "published", block:)).to eq(snippets)
+      expect(described_class.for_content_id(content_id, state: "published", block:, locale: "en")).to eq(snippets)
     end
 
     it "fetches draft content from the draft store and joins guide parts into a single fragment" do
@@ -55,7 +55,7 @@ RSpec.describe BlockPreview::Snippet do
         expect(html_fragment.to_html).to include("<p>Part two</p>")
       }.and_return(diff)
 
-      described_class.for_content_id(content_id, state: "draft", block:)
+      described_class.for_content_id(content_id, state: "draft", block:, locale: "en")
     end
   end
 

--- a/engines/block_preview/spec/unit/app/models/snippet_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/snippet_spec.rb
@@ -1,4 +1,64 @@
 RSpec.describe BlockPreview::Snippet do
+  describe ".for_content_id" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:base_path) { "/test-path" }
+    let(:block) { instance_double("ContentBlock") }
+    let(:diff_output) { "<main>DIFF_HTML</main>" }
+    let(:snippets) { [instance_double(described_class)] }
+    let(:publishing_api_response) { { "base_path" => base_path } }
+    let(:content_store) { instance_double("ContentStore") }
+    let(:diff) { instance_double(BlockPreview::ContentDiff, to_s: diff_output) }
+
+    before do
+      allow(Public::Services.publishing_api).to receive(:get_content)
+        .with(content_id)
+        .and_return(publishing_api_response)
+      allow(described_class).to receive(:from_html).with(diff_output).and_return(snippets)
+      allow(BlockPreview::ContentDiff).to receive(:new).and_return(diff)
+    end
+
+    it "fetches published content from the live content store and parses details.body" do
+      allow(Public::Services).to receive(:content_store).and_return(content_store)
+      allow(content_store).to receive(:content_item).with(base_path).and_return(
+        {
+          "document_type" => "answer",
+          "details" => { "body" => "<p>Published body</p>" },
+        },
+      )
+
+      expect(BlockPreview::ContentDiff).to receive(:new) { |html_fragment, received_block|
+        expect(html_fragment).to be_a(Nokogiri::HTML::DocumentFragment)
+        expect(html_fragment.to_html).to eq("<p>Published body</p>")
+        expect(received_block).to be(block)
+      }.and_return(diff)
+
+      expect(described_class.for_content_id(content_id, state: "published", block:)).to eq(snippets)
+    end
+
+    it "fetches draft content from the draft store and joins guide parts into a single fragment" do
+      allow(Public::Services).to receive(:draft_content_store).and_return(content_store)
+      allow(content_store).to receive(:content_item).with(base_path).and_return(
+        {
+          "document_type" => "guide",
+          "details" => {
+            "parts" => [
+              { "body" => "<p>Part one</p>" },
+              { "body" => "<p>Part two</p>" },
+            ],
+          },
+        },
+      )
+
+      expect(BlockPreview::ContentDiff).to receive(:new) { |html_fragment, _received_block|
+        expect(html_fragment).to be_a(Nokogiri::HTML::DocumentFragment)
+        expect(html_fragment.to_html).to include("<p>Part one</p>")
+        expect(html_fragment.to_html).to include("<p>Part two</p>")
+      }.and_return(diff)
+
+      described_class.for_content_id(content_id, state: "draft", block:)
+    end
+  end
+
   describe ".from_html" do
     it "returns an empty array when there are no content blocks" do
       html = <<~HTML

--- a/engines/block_preview/spec/unit/app/models/snippet_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/snippet_spec.rb
@@ -196,6 +196,20 @@ RSpec.describe BlockPreview::Snippet do
     end
   end
 
+  describe "#context_parent" do
+    it "does not raise when walking up reaches a document node" do
+      document = instance_double(Nokogiri::HTML4::Document, previous_element: nil)
+      block = instance_double(Nokogiri::XML::Node, parent: document)
+      allow(block).to receive(:ancestors).with("li").and_return([])
+      allow(block).to receive(:ancestors).with("td").and_return([])
+
+      snippet = described_class.new(nil, block)
+
+      expect { snippet.context_parent }.not_to raise_error
+      expect(snippet.context_parent).to eq(document)
+    end
+  end
+
   describe "#to_html" do
     let(:doc) { Nokogiri::HTML(html) }
     let(:block) { doc.at_css(css_selector) }

--- a/features/pension/edit_block.feature
+++ b/features/pension/edit_block.feature
@@ -132,6 +132,7 @@ Feature: Edit a pension block
   @javascript
   Scenario: GDS editor can preview a host document
     Given there is a published host document with a link
+    And the show_snippets feature flag is not turned on
     When I revisit the edit page
     And I save and continue
     When I click on the first host document
@@ -142,6 +143,7 @@ Feature: Edit a pension block
   @javascript
   Scenario: GDS editor can preview a host document within a smart answer
     Given there is a host document that is a smart answer
+    And the show_snippets feature flag is not turned on
     When I revisit the edit page
     And I save and continue
     When I click on the first host document

--- a/features/step_definitions/preview_steps.rb
+++ b/features/step_definitions/preview_steps.rb
@@ -44,6 +44,11 @@ Given(/^there is a (draft|published) host document with a link$/) do |host_type|
   stub_publishing_api_has_embedded_content_details(@dependent_content.first, "en", host_type)
 end
 
+Given(/^the show_snippets feature flag is( not)? turned on$/) do |negated|
+  allow(Flipflop).to receive(:enabled?).and_call_original
+  allow(Flipflop).to receive(:enabled?).with(:show_snippets).and_return(negated.nil?)
+end
+
 Given("there is a host document that is a smart answer") do
   @current_host_document = @dependent_content.first
   embed_code = "{{embed:#{@current_host_document['block_type']}:#{@current_host_document['content_id']}}}"


### PR DESCRIPTION
This adds a prototype view of what a "snippet-based" preview would look like when previewing a document. This finds where blocks are embedded on a page ~~(note: doesn't yet support multi-page documents)~~ and shows the block together with some surrounding elements as "snippets".

This allows the reviewer to concentrate on the changes that the block is making to the page, rather than the page in its totality. There is also an option to show the whole page preview too.

## Screenshot

<img width="1512" height="2916" alt="image" src="https://github.com/user-attachments/assets/403bfaac-1823-4e9c-9bef-5133f3828bcc" />

This is **not yet** ready for merge, but I will deploy it to integration to demo to the wider team.