### PR TITLE
(CM-931) Show available formats on edition page

### DIFF
--- a/app/assets/javascripts/modules/copy-embed-code.js
+++ b/app/assets/javascripts/modules/copy-embed-code.js
@@ -148,6 +148,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     function () {
       this.removeEmbedCodesFromEmbeddedBlocks()
       this.removeEmbedCodeFromDefaultBlock()
+      this.removeEmbedCodeFromFormatBlocks()
     }
 
   CopyEmbedCode.prototype.removeEmbedCodesFromEmbeddedBlocks = function () {
@@ -163,6 +164,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       .querySelectorAll(
         '.app-c-content-block-manager-default-block__embed_code'
       )
+      .forEach((element) => {
+        element.remove()
+      })
+  }
+
+  CopyEmbedCode.prototype.removeEmbedCodeFromFormatBlocks = function () {
+    this.module
+      .querySelectorAll('.app-c-content-block-manager-format-block__embed_code')
       .forEach((element) => {
         element.remove()
       })

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $govuk-page-width: 1140px;
 @import "components/embedded-objects-metadata-component";
 @import "components/datetime-fields";
 @import "components/default-block-component";
+@import "components/format-block-component";
 @import "components/filter-options-component";
 @import "components/govspeak-editor";
 @import "components/host-editions-rollup-component";

--- a/app/assets/stylesheets/components/_format-block-component.scss
+++ b/app/assets/stylesheets/components/_format-block-component.scss
@@ -1,0 +1,27 @@
+@use "shared/embed_codes";
+
+.app-c-content-block-manager-format-block {
+  .govuk-summary-list__row {
+    border: none;
+
+    .govuk-summary-list__key {
+      // Hide the key in the summary list, while keeping it readable for screen reader users
+      @include govuk-visually-hidden;
+      width: 0;
+      // stylelint-disable-next-line declaration-no-important
+      position: relative !important;
+    }
+
+    .govuk-summary-list__value {
+      padding: 0;
+    }
+  }
+
+  &__embed_code {
+    color: $govuk-secondary-text-colour;
+  }
+
+  .embed-code-flash__wrapper {
+    @include embed_codes.embed-code-flash;
+  }
+}

--- a/app/components/edition/show/format_block_component.html.erb
+++ b/app/components/edition/show/format_block_component.html.erb
@@ -1,0 +1,12 @@
+<div class="app-c-content-block-manager-format-block">
+  <%= render "govuk_publishing_components/components/summary_card", {
+    title: title,
+    rows: [
+      {
+        key: "Block content",
+        value: block_content,
+        data: data_attributes,
+      },
+    ],
+  } %>
+</div>

--- a/app/components/edition/show/format_block_component.rb
+++ b/app/components/edition/show/format_block_component.rb
@@ -1,0 +1,49 @@
+class Edition::Show::FormatBlockComponent < ViewComponent::Base
+  def initialize(edition:, format:)
+    @edition = edition
+    @document = edition.document
+    @format = format
+  end
+
+private
+
+  attr_reader :edition, :document, :format
+
+  def title
+    format.humanize
+  end
+
+  def block_content
+    content = content_tag(:div, class: "govspeak") do
+      edition.render(embed_code_for_format)
+    end
+    content << embed_code_element
+
+    content
+  end
+
+  def embed_code_element
+    return unless edition.show_embed_codes?
+
+    content_tag(
+      :p,
+      embed_code_for_format,
+      class: "app-c-content-block-manager-format-block__embed_code",
+    )
+  end
+
+  def embed_code_for_format
+    @embed_code_for_format ||= document.embed_code_for_format(format)
+  end
+
+  def data_attributes
+    return { "testid": "format_block" } unless edition.show_embed_codes?
+
+    {
+      module: "copy-embed-code",
+      "embed-code": embed_code_for_format,
+      "embed-code-details": "format block",
+      "testid": "format_block",
+    }
+  end
+end

--- a/app/models/concerns/schema/configuration.rb
+++ b/app/models/concerns/schema/configuration.rb
@@ -2,9 +2,14 @@ class Schema
   module Configuration
     extend ActiveSupport::Concern
 
+    FORMATS_PROPERTY_KEY = "x-formats".freeze
     BLOCK_DISPLAY_FIELDS_PROPERTY_KEY = "x-block-display-fields".freeze
     EMBEDDABLE_AS_BLOCK_PROPERTY_KEY = "x-embeddable-as-block".freeze
     FIELD_ORDER_PROPERTY_KEY = "x-field-order".freeze
+
+    def formats
+      @body[FORMATS_PROPERTY_KEY] || []
+    end
 
     def block_display_fields
       @body[BLOCK_DISPLAY_FIELDS_PROPERTY_KEY] || []

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,6 +39,10 @@ class Document < ApplicationRecord
     "#{embed_code_prefix}/#{field_path}}}"
   end
 
+  def embed_code_for_format(format)
+    "#{embed_code_prefix}##{format}}}"
+  end
+
   def title
     @title ||= most_recent_edition&.title
   end

--- a/app/models/schema/definitions/time_period.json
+++ b/app/models/schema/definitions/time_period.json
@@ -2,6 +2,14 @@
   "type": "object",
   "additionalProperties": false,
   "x-embeddable-as-block": true,
+  "x-formats": [
+    "long_form",
+    "months_and_years_long",
+    "start_day_and_month",
+    "start_month_as_word",
+    "years",
+    "years_short"
+  ],
   "properties": {
     "description": {
       "type": "string",

--- a/app/views/documents/_formats.html.erb
+++ b/app/views/documents/_formats.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row formats__row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">
+      Available formats
+    </h2>
+    <% @schema.formats.each do |format| %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render(
+                Edition::Show::FormatBlockComponent.new(
+                  edition: @edition,
+                  format: format,
+                ),
+              ) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -82,6 +82,8 @@
   </div>
 <% end %>
 
+<%= render partial: "documents/formats" if @schema.formats.any? %>
+
 <% @subschemas.grouped.each do |group, subschemas| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,9 @@ These files define both:
 - `x-field-order`: field ordering for forms and summary metadata
 - `x-group`: logical group name for grouped subschemas (for example, contact methods)
 - `x-group-order`: ordering within a group
+- `x-formats`: a list of the available formats which are supported for this block type.
+  The formats are defined in content_block_tools. A rendered preview of each format listed
+  here is shown under the "default block" representation with the embed code for the format.
 
 ### Field-level keys
 

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -237,6 +237,39 @@ Then("the time period date range fields should be populated with the invalid val
   time_period.should_see_raw_time_period_values_in_form(raw_values: time_period.invalid_date_raw_values, page: page)
 end
 
+Then("I see the representation of each available time_period format") do
+  doc = Document.where(block_type: "time_period").last
+
+  within ".formats__row" do |row|
+    expect(row).to have_css("h2", text: "Available formats")
+
+    doc.schema.formats.each do |format|
+      within ".app-c-content-block-manager-format-block " \
+        ".gem-c-summary-card[title='#{format.humanize}']" do |format_block|
+        within ".content-block" do
+          rendered_format_block = doc.editions.last.render(doc.embed_code_for_format(format))
+          format_node = Capybara.string(rendered_format_block)
+
+          expect(format_block).to have_content(format_node.text.strip)
+        end
+      end
+    end
+  end
+end
+
+Then("I see the embed code for each available TimePeriod format") do
+  doc = Document.where(block_type: "time_period").last
+
+  doc.schema.formats.each do |format|
+    within ".app-c-content-block-manager-format-block " \
+      ".gem-c-summary-card[title='#{format.humanize}']" do |format_block|
+      within ".content-block" do
+        expect(format_block).to have_content(doc.embed_code_for_format(format))
+      end
+    end
+  end
+end
+
 def has_error_message_linking_to_field_group(message:, field_group_id:)
   expect(page).to have_selector(
     "a[href='#{field_group_id}']",

--- a/features/time_period/create_block.feature
+++ b/features/time_period/create_block.feature
@@ -24,6 +24,7 @@ Feature: Create "Time period" content block
     And the block should have been sent to the Publishing API
     When I click to view the content block
     Then I should see the details for the time_period content block
+    And I see the representation of each available time_period format
 
   Scenario: Time period validates correctly
     When I fill the form with the following fields:

--- a/features/time_period/use_embed_codes.feature
+++ b/features/time_period/use_embed_codes.feature
@@ -17,14 +17,6 @@ Feature: Editor uses time period embed codes
     Given I am viewing the published edition
     Then I see embed code for the default time period block
 
-  @wip
-  Scenario: Copy day of the month e.g. '06'
-    # what about formatted day, e.g. '6'?
-
-  @wip
-  Scenario: Copy month e.g. '04'
-    # what about formatted month, e.g. 'April'
-
-  @wip
-  Scenario: Copy year e.g. '2026'
-    # what about formatted year e.g. '26', e.g. to construct '2025-26'?
+  Scenario: Copy codes for formats
+    Given I am viewing the published edition
+    Then I see the embed code for each available TimePeriod format

--- a/spec/components/edition/show/format_block_component_spec.rb
+++ b/spec/components/edition/show/format_block_component_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe Edition::Show::FormatBlockComponent, type: :component do
+  let(:document) { build(:document, :time_period, content_id_alias: "tax-year") }
+  let(:edition) { build(:edition, :time_period, :published, document: document) }
+
+  let(:format) { "my_format" }
+  let(:embed_code_for_format) { "{{embed:content_block_time_period:tax-year##{format}}}" }
+  let(:embed_code_details) { "format block" }
+  let(:format_block_output) { "FORMAT_BLOCK_OUTPUT" }
+
+  before do
+    allow(edition).to receive(:render).with(embed_code_for_format).and_return(format_block_output)
+  end
+
+  context "when Edition#show_embed_codes? is _true_" do
+    before do
+      allow(edition).to receive(:show_embed_codes?).and_return(true)
+      render_inline(Edition::Show::FormatBlockComponent.new(edition: edition, format: format))
+    end
+
+    it "includes the format block output in a govspeak enabled element" do
+      expect(page).to have_css(
+        ".govspeak",
+        text: format_block_output,
+      )
+    end
+
+    it "includes the format's embed code in its own element" do
+      expect(page).to have_css(
+        ".govuk-summary-list__value .app-c-content-block-manager-format-block__embed_code",
+        text: "{{embed:content_block_time_period:tax-year#my_format}}",
+      )
+    end
+
+    it "includes 'data' attributes to initialise the CopyEmbedCode JS module" do
+      data_attrs = [
+        "[data-module='copy-embed-code']",
+        "[data-embed-code='{{embed:content_block_time_period:tax-year#my_format}}']",
+        "[data-embed-code-details='format block']",
+      ]
+
+      expect(page).to have_css("div#{data_attrs.join}")
+    end
+  end
+
+  context "when Edition#show_embed_codes? is _false_" do
+    before do
+      allow(edition).to receive(:show_embed_codes?).and_return(false)
+      render_inline(Edition::Show::FormatBlockComponent.new(edition: edition, format: format))
+    end
+
+    it "includes the format block output in a govspeak enabled element" do
+      expect(page).to have_css(
+        ".govspeak",
+        text: format_block_output,
+      )
+    end
+
+    it "does NOT include the format's embed code in its own element" do
+      expect(page).not_to have_content(embed_code_for_format)
+    end
+
+    it "does NOT include 'data' attributes to initialise the CopyEmbedCode JS module" do
+      data_attrs = [
+        "[data-module='copy-embed-code']",
+        "[data-embed-code='{{embed:content_block_time_period:tax-year#my_format}}']",
+        "[data-embed-code-details='format block']",
+      ]
+
+      expect(page).to have_no_css("div#{data_attrs.join}")
+    end
+  end
+end

--- a/spec/javascripts/copy-embed-code.spec.js
+++ b/spec/javascripts/copy-embed-code.spec.js
@@ -16,6 +16,9 @@ describe('GOVUK.Modules.CopyEmbedCode', function () {
       <p class="app-c-content-block-manager-default-block__embed_code">
         {{embed:content_block_contact:block-name}}
       </p>
+      <p class="app-c-content-block-manager-format-block__embed_code">
+        {{embed:content_block_contact:block-name#my_format}}
+      </p>
       <dt class="govuk-summary-list__value">
         <div class="app-c-embedded-objects-blocks-component__content">
           <div data-embed-code="{{embed:content_block_contact:block-name}}">
@@ -66,6 +69,13 @@ describe('GOVUK.Modules.CopyEmbedCode', function () {
       it('should remove the visible code from the the default block', function () {
         const ele = fixture.querySelector(
           '.app-c-content-block-manager-default-block__embed_code'
+        )
+        expect(ele).not.toEqual(jasmine.anything())
+      })
+
+      it('should remove the visible code from the format block', function () {
+        const ele = fixture.querySelector(
+          '.app-c-content-block-manager-format-block__embed_code'
         )
         expect(ele).not.toEqual(jasmine.anything())
       })

--- a/spec/support/schema_helpers.rb
+++ b/spec/support/schema_helpers.rb
@@ -43,6 +43,7 @@ module SchemaHelpers
         },
       },
       block_type:,
+      formats: [],
       permitted_params: %i[foo bar],
       subschemas:,
       block_display_fields: [],

--- a/spec/unit/app/models/document_spec.rb
+++ b/spec/unit/app/models/document_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe Document, type: :model do
     end
   end
 
+  describe "#embed_code_for_format(format)" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:content_id_alias) { "tax-year" }
+    let(:document) { create(:document, :time_period, content_id:, content_id_alias:) }
+
+    it "applies the format specifier to the base embed code (field formats not supported)" do
+      expect(document.embed_code_for_format("long")).to eq(
+        "{{embed:content_block_time_period:tax-year#long}}",
+      )
+    end
+  end
+
   describe "latest_published_edition" do
     let(:document) { create(:document, :pension) }
 

--- a/spec/unit/app/models/schema/configuration_spec.rb
+++ b/spec/unit/app/models/schema/configuration_spec.rb
@@ -2,6 +2,26 @@ RSpec.describe Schema::Configuration do
   let(:body) { { "properties" => { "foo" => {}, "bar" => {}, "title" => {} } } }
   let(:schema) { build(:schema, :pension, body:) }
 
+  describe "#formats" do
+    describe "when `x-formats` is set in the schema body" do
+      let(:body) do
+        {
+          "x-formats" => %w[long short],
+        }
+      end
+
+      it "returns the formats from the JSON body" do
+        expect(schema.formats).to eq(%w[long short])
+      end
+    end
+
+    describe "when `x-formats` is not set in the schema body" do
+      it "returns an empty list" do
+        expect(schema.formats).to eq([])
+      end
+    end
+  end
+
   describe "#block_display_fields" do
     describe "when `x-block-display-fields` is set in the schema body" do
       let(:body) do


### PR DESCRIPTION
See  Jira [CM-931](https://gov-uk.atlassian.net/browse/CM-931)

---

## User story

- So that I can copy the embed code for the format which I want to use
- As an editor viewing a particular block
- I want to see its various formats as well as the “default block”

---

In this PR we use the new format "specifier functionality" introduced in Content Block Tools [PR 147](https://github.com/alphagov/govuk_content_block_tools/pull/147) to show all available formats on the main "edition page" after the "default block".

<img width="983" height="2322" alt="available_formats" src="https://github.com/user-attachments/assets/045c169e-b649-4406-a122-c82406930e09" />



[CM-931]: https://gov-uk.atlassian.net/browse/CM-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ