### PR TITLE
Remove `required_ruby_version` from engines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,3 +60,8 @@ Rails/RakeEnvironment:
     - 'lib/tasks/coverage.rake'
     - 'lib/tasks/converter.rake'
     - 'lib/tasks/lint.rake'
+
+# Don't require a Ruby version to be specified in gemspecs within engines.
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - 'engines/**/*.gemspec'

--- a/engines/block_preview/block_preview.gemspec
+++ b/engines/block_preview/block_preview.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |spec|
   spec.email   = ["govuk-dev@digital.cabinet-office.gov.uk"]
   spec.summary = "Rails engine for Block Preview."
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 4.0.2"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,lib}/**/*"]

--- a/engines/fact_check/fact_check.gemspec
+++ b/engines/fact_check/fact_check.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |spec|
   spec.email   = ["govuk-dev@digital.cabinet-office.gov.uk"]
   spec.summary = "Rails engine for Fact Check."
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 4.0.2"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,lib}/**/*"]


### PR DESCRIPTION
This is stopping Dependabot from running, as it doesn’t _technically_ support Ruby 4 yet.