### PR TITLE
(CM-916) Set default locale value to "en"

### DIFF
--- a/engines/block_preview/app/model/block_preview/preview_content.rb
+++ b/engines/block_preview/app/model/block_preview/preview_content.rb
@@ -8,7 +8,7 @@ module BlockPreview
       @content_id = content_id
       @block = block
       @base_path = base_path
-      @locale = locale
+      @locale = locale.presence || "en"
       @state = validated_state(state)
     end
 

--- a/engines/block_preview/spec/unit/app/models/preview_content_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_content_spec.rb
@@ -143,6 +143,15 @@ RSpec.describe BlockPreview::PreviewContent do
       allow(BlockPreview::PreviewHtml).to receive(:new).and_return(preview_html_response)
     end
 
+    context "when the locale is empty" do
+      let(:locale) { "" }
+
+      it "defaults the locale to 'en'" do
+        preview_content.html
+        expect(BlockPreview::PreviewHtml).to have_received(:new).with(hash_including(locale: "en"))
+      end
+    end
+
     it "builds preview html using the host content base path by default" do
       expect(preview_content.html).to eq(html)
 


### PR DESCRIPTION
This fixes a bug related to a URL to view a preview of a published document, e.g. https://content-block-manager.integration.publishing.service.gov.uk/preview/a248f622-8acb-4cc0-b46e-1c39c792d243/edition/551?locale=en&state=published.

We have found that removing the “locale” value or removing the key/value pair entirely causes a 404 error. By explicitly setting the locale to “en” if the parameter value is falsy or an empty string, we avoid this error.

Jira ticket: https://gov-uk.atlassian.net/browse/CM-916.

https://github.com/user-attachments/assets/c769d739-a2a3-4ba5-b954-3ed8dc3022ea