### PR TITLE
CM-927: add accessibility information to footer

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,3 @@
+class PagesController < ApplicationController
+  def accessibility_statement; end
+end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -113,6 +113,14 @@
       ga4_no_copy: true,
     },
     hide_licence: true,
+    meta: {
+      items: [
+        {
+          href: "/accessibility-statement",
+          text: "Accessibility statement",
+        },
+      ],
+    },
     navigation: [
       {
         title: "Support and feedback",

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Accessibility statement for Content Block Manager</h1>
+    <p class="govuk-body">This accessibility statement applies to content published on the <%= link_to "content-block-manager.publishing.service.gov.uk", "https://content-block-manager.publishing.service.gov.uk", class: "govuk-link" %> domain.</p>
+    <p class="govuk-body">This website is run by the Government Digital Service. We want as many people as possible to be able to use this website. For example, that means you should be able to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>change colours, contrast levels and fonts using browser or device settings</li>
+      <li>zoom in up to 400% without the text spilling off the screen</li>
+      <li>navigate most of the website using a keyboard or speech recognition software</li>
+      <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+    </ul>
+    <p class="govuk-body">We’ve also made the website text as simple as possible to understand.</p>
+    <h2 class="govuk-heading-l">Feedback and contact information</h2>
+    <p class="govuk-body">If you find any problems not listed on this page or think we’re not meeting accessibility requirements, <%= link_to "contact us", "https://www.gov.uk/contact/govuk", class: "govuk-link" %>.</p>
+    <p class="govuk-body">You can also <%= link_to "tell us if you need information in a different format", "https://www.gov.uk/contact/govuk", class: "govuk-link" %>.</p>
+    <h2 class="govuk-heading-l">Enforcement procedure</h2>
+    <p class="govuk-body">
+      The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the <%= link_to "Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com", class: "govuk-link" %>.
+    </p>
+    <h2 class="govuk-heading-l">Technical information about this website’s accessibility</h2>
+    <p class="govuk-body">The Government Digital Service is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+    <h3 class="govuk-heading-m">Compliance status</h3>
+    <p class="govuk-body">This website is fully compliant with the <%= link_to "Web Content Accessibility Guidelines version 2.2", "https://www.w3.org/TR/WCAG22", class: "govuk-link" %> AA standard.</p>
+    <h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
+    <p class="govuk-body">This statement was prepared on 5 May 2026.</p>
+    <p class="govuk-body">This website was last tested in December 2024 against the WCAG 2.2 AA standard.</p>
+    <p class="govuk-body">The test was carried out by a Senior Accessibility Specialist at <%= link_to "GOV.UK", "https://www.gov.uk/", class: "govuk-link" %> using automated testing tools.</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ require "govuk_sidekiq/gds_sso_middleware"
 Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+  get "/accessibility-statement", to: "pages#accessibility_statement"
   mount Flipflop::Engine => "/flipflop"
   mount FactCheck::Engine => "/fact-check"
   mount BlockPreview::Engine => "/preview"

--- a/features/content_block_manager.feature
+++ b/features/content_block_manager.feature
@@ -22,3 +22,10 @@ Feature: Content block manager
     Given I do not have the "pre_release_features" permission
     When I visit the Content Block Manager home page
     Then I do not see the warning that the pre-release features are enabled
+
+  Scenario: Follow link to accessibility statement
+    When I visit the Content Block Manager home page
+    Then I see the "Accessibility statement" link in the footer
+    When I click the "Accessibility statement" link
+    Then I am on the accessibility statement page
+    And I see the heading "Accessibility statement"

--- a/features/step_definitions/content_block_manager_steps.rb
+++ b/features/step_definitions/content_block_manager_steps.rb
@@ -453,3 +453,19 @@ end
 Then(/^the duplicate title validation check will have been skipped$/) do
   expect(page).to_not have_content(I18n.t("activerecord.errors.models.edition.title.not_unique"))
 end
+
+Then(/^I see the "Accessibility statement" link in the footer$/) do
+  expect(page).to have_link("Accessibility statement", href: accessibility_statement_path)
+end
+
+When(/^I click the "Accessibility statement" link$/) do
+  click_link "Accessibility statement"
+end
+
+Then(/^I am on the accessibility statement page$/) do
+  expect(page).to have_current_path(accessibility_statement_path)
+end
+
+And(/^I see the heading "Accessibility statement"$/) do
+  expect(page).to have_selector("h1", text: "Accessibility statement")
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Pages", type: :request do
+  before do
+    logout
+    user = create(:user)
+    login_as(user)
+  end
+  describe "GET /accessibility_statement" do
+    it "returns http success" do
+      get "/accessibility-statement"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Adds an accessibility statement to the service, rendered via a new PagesController.

Jira ticket: https://gov-uk.atlassian.net/browse/CM-927
<img width="1272" height="592" alt="Screenshot 2026-05-07 at 15 55 22" src="https://github.com/user-attachments/assets/f0641be2-1d08-4519-8ed9-ab32c263f68f" />
<img width="780" height="782" alt="Screenshot 2026-05-07 at 15 55 51" src="https://github.com/user-attachments/assets/626954e1-1f21-4854-b372-31b0937e5bb4" />
<img width="639" height="677" alt="Screenshot 2026-05-07 at 15 56 03" src="https://github.com/user-attachments/assets/6c04abc6-ac18-472e-97e2-fa5dda535f68" />
