### PR TITLE
CM-936 content changes to hint text

### DIFF
--- a/app/components/edition/show/notes_summary_card_component.rb
+++ b/app/components/edition/show/notes_summary_card_component.rb
@@ -30,7 +30,7 @@ private
 
   def major_change_item
     {
-      key: "Do users have to know the content has changed?",
+      key: "Do you need to tell users the content has changed?",
       value: edition.major_change ? "Yes" : "No",
       actions: [
         {

--- a/app/views/editions/workflow/change_note.html.erb
+++ b/app/views/editions/workflow/change_note.html.erb
@@ -18,15 +18,14 @@
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "edition[major_change]",
-        hint: "Some content types show public change notes. GOV.UK users can subscribe to email alerts and RSS feeds to receive public change notes. Telling users when published information has changed is important for transparency.",
-        id: "content_block_manager_edition_major_change",
+        hint: "<p class='govuk-body govuk-!-margin-bottom-2'>GOV.UK users can subscribe to email alerts and RSS feeds to receive public change notes. Telling users when published information has changed is important for transparency.</p><h2 class='govuk-heading-m govuk-!-margin-bottom-2'>Where change notes are published</h2><p class='govuk-body govuk-!-margin-bottom-2'> A change note is published on every page containing the content block and emailed to users. The 'last updated' date will change on the pages that display it.".html_safe,
+id: "content_block_manager_edition_major_change",
         error_items: errors_for(@edition.errors, :major_change),
         items: [
           {
             value: "1",
             checked: @edition.major_change === true,
-            text: "Yes - information has been added, updated or removed",
-            hint_text: "A change note will be published on every relevant page containing the content block you've changed. Change notes will also be emailed to users subscribed to email alerts for every page affected by this change. The 'last updated' date will change on pages that display it.",
+            text: "Yes - information has changed",
             bold: true,
             conditional: render("govuk_publishing_components/components/textarea", {
               label: {
@@ -37,14 +36,14 @@
               id: "content_block_manager_edition_change_note",
               error_items: errors_for(@edition.errors, :change_note),
               value: @edition.change_note,
-              hint: "Tell users what has been edited, where and why. Write in full sentences, leading with the most important words. For example, \"The full basic State Pension rate has changed from £156.20 per week to £169.50 per week.\"",
+              hint: "Tell users what has been edited, where and why",
             }),
           },
           {
             value: "0",
             checked: @edition.major_change === false,
-            text: "No - it's a minor edit that does not change the meaning",
-            hint_text: "This includes fixing a typo or broken link, a style change or similar. Users signed up to email alerts will not get notified and the 'last updated' date will not change.",
+            text: "No, I made minor edits only",
+            hint_text: "For example, fixing a typo or broken link",
             bold: true,
           },
         ],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,42 +150,40 @@ en:
           title: Select publish date
     hints:
       instructions_to_publishers_html: |
-        Add information that’s important for anyone using or editing this block to know. For example, who to contact about the block if you have questions. <br/>
-        Not displayed on GOV.UK.
-      lead_organisation: Not displayed on GOV.UK.
-      not_displayed: Not displayed on GOV.UK.
+        Add important information about using or editing the block, not displayed on GOV.UK
+      lead_organisation: Not displayed on GOV.UK
+      not_displayed: Not displayed on GOV.UK
       contact:
         title: Explain the purpose of the contact, for example ‘Contact the Pension Service’, ‘Universal Credit helpline’
-        description: For example, is there anything the user should know, prepare or include before using any contact method.
+        description: Add anything the user should know, prepare or include before using any contact method
         contact_links:
-          label: This will display as link text.
-          url: This should be the full URL e.g. 'https://example.com/document.html'
-          description: For example, is there anything the user should know, prepare or include before using the contact link.
+          label: Displayed as a link
+          url: Enter a URL in the correct format, for example, https://example.com/document.html
+          description: Add anything the user should know, prepare or include before using the contact link
         addresses:
-          description: For example, is there anything the user should know, prepare or include before using the address.
+          description: Add anything the user should know, prepare or include before using the address
         email_addresses:
-          email_address: Write email addresses in full, in lower case. Prioritise team email addresses over personal email addresses for users.
-          subject: Set a default subject line that will automatically pre-fill when users send an email using the email link.
-          body: Set default body content that will automatically pre-fill when users send an email using the email link.
+          email_address: Enter a team email address in full and lowercase, for example, team@example.com
+          subject: Set a default subject line that will automatically pre-fill when users send an email using the email link
+          body: Set default body content that will automatically pre-fill when users send an email using the email link
           description:
-            "For example, is there anything the user should know, prepare or include before using the email address. 
-             You can repeat the content for ‘Subject’ and ‘Body’ for users who do not use the email link."
+            Add anything the user should know, prepare or include before using the email address
         telephones:
-          description: For example, is there anything the user should know, prepare or include before telephoning.
+          description: Add anything the user should know, prepare or include before telephoning
           call_charges:
-            show_call_charges_info_url: For example, consider if this telephone number has UK call charges.
+            show_call_charges_info_url: Tell the user about any call charges
           telephone_numbers:
-            label: For example, Telephone, Textphone, Welsh language.
+            label: For example, Telephone, Textphone, Welsh language
           video_relay_service:
-            show: Only select this option if your organisation has subscribed to an interpreter service.
+            show: Only select this option if your organisation has subscribed to an interpreter service
           bsl_guidance:
-            show: Only select this option if your organisation has subscribed to an interpreter service.
+            show: Only select this option if your organisation has subscribed to an interpreter service
       govspeak_enabled: Govspeak enabled
       pension:
         rates:
-          amount: "Enter an exact amount, with the currency symbol - for example: £122.50"
+          amount: Enter an exact amount of money
       tax:
-        description: "A summary of the tax, for example, 'Capital Gains Tax is a tax on the profit when you sell something that’s increased in value.'"
+        description: A summary of the tax, for example, 'Capital Gains Tax is a tax on the profit when you sell something that’s increased in value'
         things_taxed:
           title: For example ‘the estate of someone who’s died’, ‘income’
           type: For profits or estate value choose 'entity value', for goods and services choose 'activity'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,7 @@ en:
         cancel:
           title: Do you want to save your draft, or delete it?
         change_note:
-          title: Do users have to know the content has changed?
+          title: Do you need to tell users the content has changed?
         confirmation:
           title: Your content block is available for use
         add_embedded_object:

--- a/features/step_definitions/review_steps.rb
+++ b/features/step_definitions/review_steps.rb
@@ -45,8 +45,8 @@ def complete_note_step
 end
 
 def complete_change_note_step
-  expect(page).to have_content("Do users have to know the content has changed?")
-  choose("No - it's a minor edit that does not change the meaning")
+  expect(page).to have_content("Do you need to tell users the content has changed?")
+  choose("No, I made minor edits only")
   click_button("Save and continue")
 end
 

--- a/features/step_definitions/workflow_steps.rb
+++ b/features/step_definitions/workflow_steps.rb
@@ -68,7 +68,7 @@ end
 
 def validate_change_note_path_and_continue
   expect(current_path).to eq(workflow_path(edition, step: :change_note))
-  choose "No - it's a minor edit that does not change the meaning"
+  choose "No, I made minor edits only"
   click_button "Save and continue"
 end
 

--- a/features/support/form_step_helpers.rb
+++ b/features/support/form_step_helpers.rb
@@ -40,7 +40,7 @@ def should_be_on_review_step(object_type: "email_address")
 end
 
 def should_be_on_change_note_step
-  assert_text "Do users have to know the content has changed?"
+  assert_text "Do you need to tell users the content has changed?"
 end
 
 def fill_in_embedded_object_form(object_type, table)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -143,7 +143,7 @@ end
 
 def add_change_note
   @change_note = "Some text"
-  choose "Yes - information has been added, updated or removed"
+  choose "Yes - information has changed"
   fill_in "Describe the edit for users", with: @change_note
   click_save_and_continue
 end

--- a/spec/components/edition/show/notes_summary_card_component_spec.rb
+++ b/spec/components/edition/show/notes_summary_card_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Edition::Show::NotesSummaryCardComponent, type: :component do
       expect(page).to have_css ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions", text: "Edit"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{workflow_path(id: edition.id, step: :internal_note)}']"
 
-      expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Do users have to know the content has changed?"
+      expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Do you need to tell users the content has changed?"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "Yes"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions", text: "Edit"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{workflow_path(id: edition.id, step: :change_note)}']"
@@ -50,7 +50,7 @@ RSpec.describe Edition::Show::NotesSummaryCardComponent, type: :component do
       expect(page).to have_css ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions", text: "Edit"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{workflow_path(id: edition.id, step: :internal_note)}']"
 
-      expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Do users have to know the content has changed?"
+      expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Do you need to tell users the content has changed?"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "No"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions", text: "Edit"
       expect(page).to have_css ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{workflow_path(id: edition.id, step: :change_note)}']"


### PR DESCRIPTION
Mostly changes to hint text, as well as the screenshotted changes to the "Do you need to tell users the content has changed?" page.

Jira ticket: https://gov-uk.atlassian.net/browse/CM-936

<img width="683" height="665" alt="Screenshot 2026-05-13 at 11 23 38" src="https://github.com/user-attachments/assets/afadbbce-429e-403d-9bcb-1e9c2c52dfc6" />
