### PR TITLE
Add 'tax_table' format to tax block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
     constant_resolver (0.3.0)
-    content_block_tools (1.12.2)
+    content_block_tools (1.13.0)
       actionview (>= 6, < 8.1.4)
       gds-api-adapters (>= 101.0)
       govspeak (>= 10.6.3)
@@ -1047,7 +1047,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   constant_resolver (0.3.0) sha256=b94886294298fb8d5db3715bac65e65493fae7b12b8a6f867cbf898944e64e83
-  content_block_tools (1.12.2) sha256=eae49303f85ef58e773c83e3ddf69b4fb8e6c2a1820db65981760b1d3dda8685
+  content_block_tools (1.13.0) sha256=b7403a7bbda5decff32435e8f437baab8a628a628f52dc8dd7d4ddc9f8230ece
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cucumber (10.2.0) sha256=fdedbd31ecf40858b60f04853f2aa15c44f5c30bbac29c6a227fa1e7005a8158

--- a/app/models/schema/definitions/tax.json
+++ b/app/models/schema/definitions/tax.json
@@ -2,6 +2,7 @@
   "type": "object",
   "required": ["tax_type"],
   "additionalProperties": false,
+  "x-formats": ["tax_table"],
   "x-field-order": ["title", "abbreviation", "synonym", "tax_type", "description", "note"],
   "properties": {
     "abbreviation": {


### PR DESCRIPTION
## User story

- So that an editor can easily embed a table of tax rates and bands
- As a content editor
- I want to embed a tax table with a single embed code using a format

---

We now offer a "tax_table" format to display a table of bands and rates using a single embed code, e.g.

```
{{embed:content_block_tax:income-tax#tax_table}}
```

Given a tax object for income tax as per https://www.gov.uk/income-tax-rates this will render a table of 12 values like:

```

| Band               | Taxable income      | Tax rate |
| ------------------ | ------------------- | -------- |
| Personal Allowance | Up to £12,570       | 0%       |
| Basic rate         | £12,571 to £50,270  | 20%      |
| Higher rate        | £50,271 to £125,140 | 40%      |
| Additional rate    | over £125,140       | 45%      |

```

<img width="798" height="1046" alt="generic_tax_table" src="https://github.com/user-attachments/assets/cb3b2b44-b710-484c-92a4-d47342dbc4e3" />

---

If the tax block can't be formatted as a tax table, we show a standard error message (as per https://github.com/alphagov/govuk_content_block_tools/pull/182):

<img width="1109" height="1254" alt="format_not_applicable_std_failure_msg" src="https://github.com/user-attachments/assets/3f67ca7c-b7d0-4d66-90ad-5586c77ebe3e" />

