### PR TITLE
Replace data-test-id with data-testid

### DIFF
--- a/app/components/shared/embedded_object/summary_card_component.rb
+++ b/app/components/shared/embedded_object/summary_card_component.rb
@@ -62,7 +62,7 @@ private
   end
 
   def data_attributes
-    test_id_prefix.present? ? { "test-id" => [test_id_prefix, object_type].join("_") } : {}
+    test_id_prefix.present? ? { "testid" => [test_id_prefix, object_type].join("_") } : {}
   end
 
   def rendered_value_for_field(field_name, _value)

--- a/app/components/shared/embedded_objects/summary_card_component.rb
+++ b/app/components/shared/embedded_objects/summary_card_component.rb
@@ -93,6 +93,6 @@ private
   end
 
   def data_attributes
-    test_id_prefix.present? ? { "test-id" => [test_id_prefix, object_title].join("_") } : {}
+    test_id_prefix.present? ? { "testid" => [test_id_prefix, object_title].join("_") } : {}
   end
 end

--- a/features/step_definitions/embedded_object_steps.rb
+++ b/features/step_definitions/embedded_object_steps.rb
@@ -190,7 +190,7 @@ end
 When(/^I click to edit the first (.+)$/) do |type|
   @content_block ||= Edition.all.last
   key = @content_block.details[type.pluralize].keys.first
-  within "div[data-test-id=embedded_#{key}]" do
+  within "div[data-testid=embedded_#{key}]" do
     click_on "Edit"
   end
 end

--- a/spec/components/shared/embedded_objects/summary_card_component_spec.rb
+++ b/spec/components/shared/embedded_objects/summary_card_component_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Shared::EmbeddedObjects::SummaryCardComponent, type: :component d
 
     render_inline component
 
-    expect(page).to have_css ".gem-c-summary-card[data-test-id='prefix_my-embedded-object']"
+    expect(page).to have_css ".gem-c-summary-card[data-testid='prefix_my-embedded-object']"
   end
 
   it "renders a summary list with a collection" do

--- a/spec/requests/workflow_spec.rb
+++ b/spec/requests/workflow_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Workflow", type: :request do
           it "displays the subschema in a single summary card" do
             get workflow_path(id: edition.id, step: :review)
 
-            expect(page).to have_css(".gem-c-summary-card[data-test-id='review_sole_embedded_date_range']")
+            expect(page).to have_css(".gem-c-summary-card[data-testid='review_sole_embedded_date_range']")
           end
         end
       end


### PR DESCRIPTION
# Jira Ticket
https://gov-uk.atlassian.net/browse/CM-958

# Description
Playwright expects `data-testid` (`data-test-id` is a typo). I've replaced it here so we can use getByTestId in our playwright tests.

I believe the govuk e2e tests will fail when this is merged so we should hold off merging this here until we're ready to merge my change to those at the same time