### PR TITLE
(CM-951) Search endpoint for API

### DIFF
--- a/.github/workflows/check-open-api.yml
+++ b/.github/workflows/check-open-api.yml
@@ -1,0 +1,41 @@
+name: Check OpenAPI documentation is up to date
+on:
+  workflow_call:
+
+jobs:
+    check-open-api:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          with:
+            show-progress: false
+
+        - name: Setup Ruby
+          uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0
+          with:
+            bundler-cache: true
+
+        - name: Setup Postgres
+          id: setup-postgres
+          uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main
+
+        - name: Initialize database
+          env:
+            RAILS_ENV: test
+            TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
+          run: bundle exec rails db:setup
+
+        - name: Build OpenAPI documentation
+          run: bundle exec rake api:generate_swagger
+          env:
+            RAILS_ENV: test
+            TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
+
+        - name: Check for uncommitted changes
+          run: |
+            if git diff --exit-code; then
+              echo "No uncommitted changes detected."
+            else
+              echo "::error title=Uncommitted changes to OpenAPI docs::If these are your changes, run \\\`rake api:generate_swagger\\\` and commit the changes."
+              exit 1
+            fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       security-events: write
       actions: read
 
+  check-open-api:
+    name: Check OpenAPI
+    uses: ./.github/workflows/check-open-api.yml
+
   lint-scss:
     name: Lint SCSS
     uses: ./.github/workflows/lintscss.yml

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails"
+  gem "rswag-specs"
   gem "rubocop-govuk"
   gem "unparser", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,6 +771,11 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
+    rswag-specs (2.17.0)
+      activesupport (>= 5.2, < 8.2)
+      json-schema (>= 2.2, < 7.0)
+      railties (>= 5.2, < 8.2)
+      rspec-core (>= 2.14)
     rubocop (1.86.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -995,6 +1000,7 @@ DEPENDENCIES
   record_tag_helper
   rinku
   rspec-rails
+  rswag-specs
   rubocop-govuk
   sentry-sidekiq
   shoulda-matchers
@@ -1037,7 +1043,6 @@ CHECKSUMS
   bootsnap (1.24.3) sha256=f7fa3d20597e2f0aa52b0a1aba83fb54d4f79e9c2e210ec4fa1e8895514dcad8
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.9) sha256=4c17fed20817b7e1bde2cfc8186e7bf5cd72017ce1aa695e35130f8e600e7282
@@ -1274,6 +1279,7 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-rails (8.0.4) sha256=06235692fc0892683d3d34977e081db867434b3a24ae0dd0c6f3516bad4e22df
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rswag-specs (2.17.0) sha256=a3b2bdf6df89f8741fe4a4ee47ceb1e77dc13e1c96bbe07352117d6e61afa9e3
   rubocop (1.86.0) sha256=4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-capybara (2.22.1) sha256=ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ To run all linter with automatic formatting corrections, run:
 bundle exec rake:lint_autocorrect
 ```
 
+### API
+
+The code for the API is in the [`engines/api`](engines/api) directory. It is a Rails engine, and uses 
+[`rswag`](https://github.com/rswag/rswag) to generate [OpenAPI documentation](engines/api/swagger) from the tests in 
+[`engines/api/spec/requests`](engines/api/spec/requests).
+
+If you make any changes to the API, then you can regenerate the OpenAPI documentation by running:
+
+```
+rake api:generate_swagger
+```
+
+This will then update the OpenAPI documentation in [`engines/api/swagger`](engines/api/swagger).
+
 ### Further documentation
 
 See the [`docs/`](docs/) directory.

--- a/app/public/models/content_block.rb
+++ b/app/public/models/content_block.rb
@@ -16,9 +16,9 @@ class ContentBlock
     @edition = edition
   end
 
-  delegate :id, :title, :state, :details, :document, :auth_bypass_id, :content_id, :render, to: :edition
-  delegate :schema, to: :document
-  delegate :embeddable_as_block?, to: :schema
+  delegate :id, :title, :state, :details, :document, :auth_bypass_id, :content_id, :render, :lead_organisation, to: :edition
+  delegate :schema, :embed_code, to: :document
+  delegate :embeddable_as_block?, :formats, to: :schema
 
   def block_type
     schema.name

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -1,9 +1,19 @@
 class ContentBlock
   class Query
-    def self.call
+    module Scopes
+      def by_block_type(block_type)
+        return self if block_type.blank?
+
+        where("block_type = ?", block_type)
+      end
+    end
+
+    def self.call(filters = {})
       Document.joins(:editions)
                   .merge(Edition.most_recent_for_document)
                   .merge(Edition.published)
+                  .extending(Scopes)
+                  .by_block_type(filters[:block_type])
                   .map { |document| ContentBlock.new(document.most_recent_edition) }
     end
   end

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -1,5 +1,39 @@
 class ContentBlock
   class Query
+    DEFAULT_PAGE_SIZE = 10
+
+    def self.call(filters = {})
+      new(filters).results
+    end
+
+    def initialize(filters)
+      @filters = filters
+    end
+
+    def results
+      unpaginated_results.page(page)
+                         .per(DEFAULT_PAGE_SIZE)
+                         .map { |document| ContentBlock.new(document.most_recent_edition) }
+    end
+
+  private
+
+    attr_reader :filters
+
+    def page
+      filters[:page].presence || 1
+    end
+
+    def unpaginated_results
+      Document.joins(:editions)
+              .merge(Edition.most_recent_for_document)
+              .merge(Edition.published)
+              .extending(Scopes)
+              .by_block_type(filters[:block_type])
+              .by_lead_organisation_id(filters[:lead_organisation_id])
+              .by_keyword(filters[:keyword])
+    end
+
     module Scopes
       def by_block_type(block_type)
         return self if block_type.blank?
@@ -18,17 +52,6 @@ class ContentBlock
 
         where("documents.id IN (?)", Document.with_keyword(keyword).pluck(:id))
       end
-    end
-
-    def self.call(filters = {})
-      Document.joins(:editions)
-                  .merge(Edition.most_recent_for_document)
-                  .merge(Edition.published)
-                  .extending(Scopes)
-                  .by_block_type(filters[:block_type])
-                  .by_lead_organisation_id(filters[:lead_organisation_id])
-                  .by_keyword(filters[:keyword])
-                  .map { |document| ContentBlock.new(document.most_recent_edition) }
     end
   end
 end

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -6,6 +6,12 @@ class ContentBlock
 
         where("block_type = ?", block_type)
       end
+
+      def by_lead_organisation_id(lead_organisation_id)
+        return self if lead_organisation_id.blank?
+
+        where("editions.lead_organisation_id = ?", lead_organisation_id)
+      end
     end
 
     def self.call(filters = {})
@@ -14,6 +20,7 @@ class ContentBlock
                   .merge(Edition.published)
                   .extending(Scopes)
                   .by_block_type(filters[:block_type])
+                  .by_lead_organisation_id(filters[:lead_organisation_id])
                   .map { |document| ContentBlock.new(document.most_recent_edition) }
     end
   end

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -1,6 +1,7 @@
 class ContentBlock
   class Query
     DEFAULT_PAGE_SIZE = 10
+    Result = Data.define(:blocks, :current_page, :total_pages, :total_count)
 
     def self.call(filters = {})
       new(filters).results
@@ -11,14 +12,21 @@ class ContentBlock
     end
 
     def results
-      unpaginated_results.page(page)
-                         .per(DEFAULT_PAGE_SIZE)
-                         .map { |document| ContentBlock.new(document.most_recent_edition) }
+      Result.new(
+        blocks: paginated_results.map { |document| ContentBlock.new(document.most_recent_edition) },
+        current_page: paginated_results.current_page,
+        total_pages: paginated_results.total_pages,
+        total_count: paginated_results.total_count,
+      )
     end
 
   private
 
     attr_reader :filters
+
+    def paginated_results
+      @paginated_results ||= unpaginated_results.page(page).per(DEFAULT_PAGE_SIZE)
+    end
 
     def page
       filters[:page].presence || 1

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -1,0 +1,10 @@
+class ContentBlock
+  class Query
+    def self.call
+      Document.joins(:editions)
+                  .merge(Edition.most_recent_for_document)
+                  .merge(Edition.published)
+                  .map { |document| ContentBlock.new(document.most_recent_edition) }
+    end
+  end
+end

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -12,6 +12,12 @@ class ContentBlock
 
         where("editions.lead_organisation_id = ?", lead_organisation_id)
       end
+
+      def by_keyword(keyword)
+        return self if keyword.blank?
+
+        where("documents.id IN (?)", Document.with_keyword(keyword).pluck(:id))
+      end
     end
 
     def self.call(filters = {})
@@ -21,6 +27,7 @@ class ContentBlock
                   .extending(Scopes)
                   .by_block_type(filters[:block_type])
                   .by_lead_organisation_id(filters[:lead_organisation_id])
+                  .by_keyword(filters[:keyword])
                   .map { |document| ContentBlock.new(document.most_recent_edition) }
     end
   end

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -1,12 +1,12 @@
 class Api::BlocksController < Api::ApplicationController
   def search
     result = ContentBlock::Query.call(filters)
-    render json: Api::BlockPresenter.present_collection(result)
+    render json: Api::BlockPresenter.present_collection(result.blocks)
   end
 
 private
 
   def filters
-    params.permit(:block_type, :lead_organisation_id, :keyword)
+    params.permit(:block_type, :lead_organisation_id, :keyword, :page)
   end
 end

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -7,6 +7,6 @@ class Api::BlocksController < Api::ApplicationController
 private
 
   def filters
-    params.permit(:block_type)
+    params.permit(:block_type, :lead_organisation_id)
   end
 end

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -1,0 +1,5 @@
+class Api::BlocksController < Api::ApplicationController
+  def search
+    render json: {}
+  end
+end

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -1,5 +1,6 @@
 class Api::BlocksController < Api::ApplicationController
   def search
-    render json: {}
+    result = ContentBlock::Query.call
+    render json: Api::BlockPresenter.present_collection(result)
   end
 end

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -1,6 +1,12 @@
 class Api::BlocksController < Api::ApplicationController
   def search
-    result = ContentBlock::Query.call
+    result = ContentBlock::Query.call(filters)
     render json: Api::BlockPresenter.present_collection(result)
+  end
+
+private
+
+  def filters
+    params.permit(:block_type)
   end
 end

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -1,7 +1,7 @@
 class Api::BlocksController < Api::ApplicationController
   def search
     result = ContentBlock::Query.call(filters)
-    render json: Api::BlockPresenter.present_collection(result.blocks)
+    render json: Api::ResultsPresenter.present(result, request.original_url)
   end
 
 private

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -7,6 +7,6 @@ class Api::BlocksController < Api::ApplicationController
 private
 
   def filters
-    params.permit(:block_type, :lead_organisation_id)
+    params.permit(:block_type, :lead_organisation_id, :keyword)
   end
 end

--- a/engines/api/app/presenters/api/block_presenter.rb
+++ b/engines/api/app/presenters/api/block_presenter.rb
@@ -1,0 +1,29 @@
+class Api::BlockPresenter
+  class << self
+    def present(block)
+      new(block).present
+    end
+
+    def present_collection(blocks)
+      blocks.map { |block| present(block) }
+    end
+  end
+
+  def initialize(block)
+    @block = block
+  end
+
+  def present
+    {
+      title: @block.title,
+      block_type: @block.block_type,
+      organisation: {
+        name: @block.lead_organisation.name,
+        content_id: @block.lead_organisation.id,
+      },
+      state: "published",
+      embed_code: @block.embed_code,
+      formats: @block.formats,
+    }
+  end
+end

--- a/engines/api/app/presenters/api/results_presenter.rb
+++ b/engines/api/app/presenters/api/results_presenter.rb
@@ -1,0 +1,73 @@
+module Api
+  class ResultsPresenter
+    class << self
+      def present(result, request_url)
+        new(result, request_url).present
+      end
+    end
+
+    def initialize(result, request_url)
+      @result = result
+      @request_url = URI.parse(request_url)
+    end
+
+    def present
+      {
+        total: result.total_count,
+        pages: result.total_pages,
+        current_page: result.current_page,
+        links:,
+        results: BlockPresenter.present_collection(result.blocks),
+      }
+    end
+
+  private
+
+    attr_reader :result, :request_url
+
+    def links
+      [previous_link, next_link, self_link].compact
+    end
+
+    def previous_link
+      return unless previous_page?
+
+      {
+        href: page_href(-1),
+        rel: "previous",
+      }
+    end
+
+    def next_link
+      return unless next_page?
+
+      {
+        href: page_href(1),
+        rel: "next",
+      }
+    end
+
+    def self_link
+      {
+        href: page_href(0),
+        rel: "self",
+      }
+    end
+
+    def page_href(offset)
+      request_url.tap { |url|
+        query_hash = Rack::Utils.parse_query(url.query)
+        query_hash["page"] = result.current_page + offset
+        url.query = Rack::Utils.build_query(query_hash)
+      }.to_s
+    end
+
+    def previous_page?
+      result.current_page > 1
+    end
+
+    def next_page?
+      result.current_page < result.total_pages
+    end
+  end
+end

--- a/engines/api/config/routes.rb
+++ b/engines/api/config/routes.rb
@@ -1,2 +1,3 @@
 Api::Engine.routes.draw do
+  get "blocks/search", to: "blocks#search"
 end

--- a/engines/api/features/api/search.feature
+++ b/engines/api/features/api/search.feature
@@ -3,34 +3,41 @@ Feature: /api/blocks/search
     Given the organisation "Ministry of Example" exists
     And the organisation "Ministry of Silly Walks" exists
     And there are the following published content blocks:
-      | title             | organisation            | block_type   |
-      | Example block 1   | Ministry of Example     | pension      |
-      | Example block 2   | Ministry of Example     | contact      |
-      | Example block 3   | Ministry of Silly Walks | time_period  |
+      | title                | organisation            | block_type   |
+      | First example block  | Ministry of Example     | pension      |
+      | Second example block | Ministry of Example     | contact      |
+      | Third example block  | Ministry of Silly Walks | time_period  |
 
   Scenario: Search for content blocks without arguments
     When I access the search API endpoint without any parameters
     Then the response is a list containing 3 blocks
     And one block has the following attributes:
-      | title           |
-      | Example block 1 |
+      | title               |
+      | First example block |
     And another block has the following attributes:
-      | title           |
-      | Example block 2 |
+      | title                |
+      | Second example block |
     And another block has the following attributes:
-      | title           |
-      | Example block 3 |
+      | title               |
+      | Third example block |
 
     Scenario: Search by block type
       When query the search API endpoint for block type "pension"
       Then the response is a list containing 1 block
       And one block has the following attributes:
-        | title           |
-        | Example block 1 |
+        | title               |
+        | First example block |
 
     Scenario: Search by organisation
       When I query the search API endpoint for the organisation "Ministry of Silly Walks"
       Then the response is a list containing 1 block
       And one block has the following attributes:
-        | title           |
-        | Example block 3 |
+        | title               |
+        | Third example block |
+
+    Scenario: Search by keyword
+      When I query the search API endpoint for the keyword "second"
+      Then the response is a list containing 1 block
+      And one block has the following attributes:
+        | title                |
+        | Second example block |

--- a/engines/api/features/api/search.feature
+++ b/engines/api/features/api/search.feature
@@ -1,4 +1,21 @@
 Feature: /api/blocks/search
-  Scenario: Search for content blocks
-    When I access the API endpoint "/api/blocks/search"
-    Then the response should have status code 200
+  Background:
+    Given the organisation "Ministry of Example" exists
+
+  Scenario: Search for content blocks without arguments
+    When there are the following published content blocks:
+      | title             | organisation        |
+      | Example block 1   | Ministry of Example |
+      | Example block 2   | Ministry of Example |
+      | Example block 3   | Ministry of Example |
+    And I access the API endpoint "/api/blocks/search"
+    Then the response is a list containing 3 blocks
+    And one block has the following attributes:
+      | title           |
+      | Example block 1 |
+    And another block has the following attributes:
+      | title           |
+      | Example block 2 |
+    And another block has the following attributes:
+      | title           |
+      | Example block 3 |

--- a/engines/api/features/api/search.feature
+++ b/engines/api/features/api/search.feature
@@ -41,3 +41,49 @@ Feature: /api/blocks/search
       And one block has the following attributes:
         | title                |
         | Second example block |
+
+    Scenario: Pagination of search results
+      Given the API has been configured to return one result per page
+      When I query the search API endpoint for the first page of results
+      Then the response is a list containing 1 block
+      And one block has the following attributes:
+        | title                |
+        | First example block |
+      And the pagination response has the following attributes:
+        | key           | value |
+        | total         | 3     |
+        | pages         | 3     |
+        | current_page  | 1     |
+      And the pagination response has the following links:
+        | rel                  | href                                            |
+        | next                 | http://www.example.com/api/blocks/search?page=2 |
+        | self                 | http://www.example.com/api/blocks/search?page=1 |
+      And I query the search API endpoint for the second page of results
+      Then the response is a list containing 1 block
+      And one block has the following attributes:
+        | title                |
+        | Second example block |
+      And the pagination response has the following attributes:
+        | key           | value |
+        | total         | 3     |
+        | pages         | 3     |
+        | current_page  | 2     |
+      And the pagination response has the following links:
+        | rel                  | href                                            |
+        | next                 | http://www.example.com/api/blocks/search?page=3 |
+        | previous             | http://www.example.com/api/blocks/search?page=1 |
+        | self                 | http://www.example.com/api/blocks/search?page=2 |
+      And I query the search API endpoint for the third page of results
+      Then the response is a list containing 1 block
+      And one block has the following attributes:
+        | title               |
+        | Third example block |
+      And the pagination response has the following attributes:
+        | key           | value |
+        | total         | 3     |
+        | pages         | 3     |
+        | current_page  | 3     |
+      And the pagination response has the following links:
+        | rel                  | href                                            |
+        | previous             | http://www.example.com/api/blocks/search?page=2 |
+        | self                 | http://www.example.com/api/blocks/search?page=3 |

--- a/engines/api/features/api/search.feature
+++ b/engines/api/features/api/search.feature
@@ -1,11 +1,12 @@
 Feature: /api/blocks/search
   Background:
     Given the organisation "Ministry of Example" exists
+    And the organisation "Ministry of Silly Walks" exists
     And there are the following published content blocks:
-      | title             | organisation        | block_type   |
-      | Example block 1   | Ministry of Example | pension      |
-      | Example block 2   | Ministry of Example | contact      |
-      | Example block 3   | Ministry of Example | time_period  |
+      | title             | organisation            | block_type   |
+      | Example block 1   | Ministry of Example     | pension      |
+      | Example block 2   | Ministry of Example     | contact      |
+      | Example block 3   | Ministry of Silly Walks | time_period  |
 
   Scenario: Search for content blocks without arguments
     When I access the search API endpoint without any parameters
@@ -26,3 +27,10 @@ Feature: /api/blocks/search
       And one block has the following attributes:
         | title           |
         | Example block 1 |
+
+    Scenario: Search by organisation
+      When I query the search API endpoint for the organisation "Ministry of Silly Walks"
+      Then the response is a list containing 1 block
+      And one block has the following attributes:
+        | title           |
+        | Example block 3 |

--- a/engines/api/features/api/search.feature
+++ b/engines/api/features/api/search.feature
@@ -1,14 +1,14 @@
 Feature: /api/blocks/search
   Background:
     Given the organisation "Ministry of Example" exists
+    And there are the following published content blocks:
+      | title             | organisation        | block_type   |
+      | Example block 1   | Ministry of Example | pension      |
+      | Example block 2   | Ministry of Example | contact      |
+      | Example block 3   | Ministry of Example | time_period  |
 
   Scenario: Search for content blocks without arguments
-    When there are the following published content blocks:
-      | title             | organisation        |
-      | Example block 1   | Ministry of Example |
-      | Example block 2   | Ministry of Example |
-      | Example block 3   | Ministry of Example |
-    And I access the API endpoint "/api/blocks/search"
+    When I access the search API endpoint without any parameters
     Then the response is a list containing 3 blocks
     And one block has the following attributes:
       | title           |
@@ -19,3 +19,10 @@ Feature: /api/blocks/search
     And another block has the following attributes:
       | title           |
       | Example block 3 |
+
+    Scenario: Search by block type
+      When query the search API endpoint for block type "pension"
+      Then the response is a list containing 1 block
+      And one block has the following attributes:
+        | title           |
+        | Example block 1 |

--- a/engines/api/features/api/search.feature
+++ b/engines/api/features/api/search.feature
@@ -1,0 +1,4 @@
+Feature: /api/blocks/search
+  Scenario: Search for content blocks
+    When I access the API endpoint "/api/blocks/search"
+    Then the response should have status code 200

--- a/engines/api/features/api/step_definitions/api_steps.rb
+++ b/engines/api/features/api/step_definitions/api_steps.rb
@@ -4,7 +4,7 @@ When("I access the search API endpoint without any parameters") do
 end
 
 Then("the response is a list containing {int} block(s)") do |count|
-  expect(@body.count).to eq(count.to_i)
+  expect(@body["results"].count).to eq(count.to_i)
 end
 
 Given(/^there are the following published content blocks:$/) do |table|
@@ -16,7 +16,7 @@ Given(/^there are the following published content blocks:$/) do |table|
 end
 
 And(/^(one|another) block has the following attributes:$/) do |_, table|
-  expect(@body).to include(hash_including table.hashes.first)
+  expect(@body["results"]).to include(hash_including(table.hashes.first))
 end
 
 When("query the search API endpoint for block type {string}") do |block_type|
@@ -33,4 +33,29 @@ end
 When("I query the search API endpoint for the keyword {string}") do |keyword|
   visit "/api/blocks/search?keyword=#{keyword}"
   @body = JSON.parse(page.source)
+end
+
+Given(/^the API has been configured to return one result per page$/) do
+  stub_const("ContentBlock::Query::DEFAULT_PAGE_SIZE", 1)
+end
+
+When(/^I query the search API endpoint for the (first|second|third) page of results$/) do |ordinal|
+  page_number = { "first" => 1, "second" => 2, "third" => 3 }[ordinal]
+  visit "/api/blocks/search?page=#{page_number}"
+  @body = JSON.parse(page.source)
+end
+
+And(/^the pagination response has the following attributes:$/) do |table|
+  table.hashes.each do |hash|
+    expect(@body[hash["key"]].to_s).to eq(hash["value"])
+  end
+end
+
+And(/^the pagination response has the following links:$/) do |table|
+  table.hashes.each do |hash|
+    expect(@body["links"]).to include({
+      "rel" => hash["rel"],
+      "href" => hash["href"],
+    })
+  end
 end

--- a/engines/api/features/api/step_definitions/api_steps.rb
+++ b/engines/api/features/api/step_definitions/api_steps.rb
@@ -1,7 +1,19 @@
 When("I access the API endpoint {string}") do |url|
   visit url
+  @body = JSON.parse(page.source)
 end
 
-Then("the response should have status code {int}") do |status_code|
-  expect(page.status_code).to eq(status_code)
+Then("the response is a list containing {int} block(s)") do |count|
+  expect(@body.count).to eq(count.to_i)
+end
+
+Given(/^there are the following published content blocks:$/) do |table|
+  table.hashes.each do |hash|
+    hash["lead_organisation_id"] = Organisation.all.find { |org| org.name == hash.delete("organisation") }.id
+    create(:edition, :published, **hash.merge(document: create(:document)))
+  end
+end
+
+And(/^(one|another) block has the following attributes:$/) do |_, table|
+  expect(@body).to include(hash_including table.hashes.first)
 end

--- a/engines/api/features/api/step_definitions/api_steps.rb
+++ b/engines/api/features/api/step_definitions/api_steps.rb
@@ -29,3 +29,8 @@ When("I query the search API endpoint for the organisation {string}") do |organi
   visit "/api/blocks/search?lead_organisation_id=#{organisation.id}"
   @body = JSON.parse(page.source)
 end
+
+When("I query the search API endpoint for the keyword {string}") do |keyword|
+  visit "/api/blocks/search?keyword=#{keyword}"
+  @body = JSON.parse(page.source)
+end

--- a/engines/api/features/api/step_definitions/api_steps.rb
+++ b/engines/api/features/api/step_definitions/api_steps.rb
@@ -1,0 +1,7 @@
+When("I access the API endpoint {string}") do |url|
+  visit url
+end
+
+Then("the response should have status code {int}") do |status_code|
+  expect(page.status_code).to eq(status_code)
+end

--- a/engines/api/features/api/step_definitions/api_steps.rb
+++ b/engines/api/features/api/step_definitions/api_steps.rb
@@ -9,8 +9,9 @@ end
 
 Given(/^there are the following published content blocks:$/) do |table|
   table.hashes.each do |hash|
-    hash["lead_organisation_id"] = Organisation.all.find { |org| org.name == hash.delete("organisation") }.id
-    create(:edition, :published, **hash.merge(document: create(:document, block_type: hash.delete("block_type"))))
+    hash["lead_organisation_id"] = Organisation.all.find { |org| org.name == hash["organisation"] }.id
+    hash["document"] = create(:document, block_type: hash["block_type"])
+    create(:edition, :published, **hash.except("block_type", "organisation"))
   end
 end
 
@@ -20,5 +21,11 @@ end
 
 When("query the search API endpoint for block type {string}") do |block_type|
   visit "/api/blocks/search?block_type=#{block_type}"
+  @body = JSON.parse(page.source)
+end
+
+When("I query the search API endpoint for the organisation {string}") do |organisation_name|
+  organisation = Organisation.all.find { |org| org.name == organisation_name }
+  visit "/api/blocks/search?lead_organisation_id=#{organisation.id}"
   @body = JSON.parse(page.source)
 end

--- a/engines/api/features/api/step_definitions/api_steps.rb
+++ b/engines/api/features/api/step_definitions/api_steps.rb
@@ -1,5 +1,5 @@
-When("I access the API endpoint {string}") do |url|
-  visit url
+When("I access the search API endpoint without any parameters") do
+  visit "/api/blocks/search"
   @body = JSON.parse(page.source)
 end
 
@@ -10,10 +10,15 @@ end
 Given(/^there are the following published content blocks:$/) do |table|
   table.hashes.each do |hash|
     hash["lead_organisation_id"] = Organisation.all.find { |org| org.name == hash.delete("organisation") }.id
-    create(:edition, :published, **hash.merge(document: create(:document)))
+    create(:edition, :published, **hash.merge(document: create(:document, block_type: hash.delete("block_type"))))
   end
 end
 
 And(/^(one|another) block has the following attributes:$/) do |_, table|
   expect(@body).to include(hash_including table.hashes.first)
+end
+
+When("query the search API endpoint for block type {string}") do |block_type|
+  visit "/api/blocks/search?block_type=#{block_type}"
+  @body = JSON.parse(page.source)
 end

--- a/engines/api/lib/tasks/generate_swagger.rake
+++ b/engines/api/lib/tasks/generate_swagger.rake
@@ -1,0 +1,7 @@
+namespace :api do
+  desc "Generate Swagger documentation from RSpec tests"
+  task generate_swagger: :environment do
+    ENV["PATTERN"] = "{spec,engines/*/spec}/**/*_spec.rb"
+    Rake::Task["rswag:specs:swaggerize"].invoke
+  end
+end

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -1,0 +1,14 @@
+require "swagger_helper"
+
+RSpec.describe "API" do
+  path "/blocks/search" do
+    get "Search content blocks" do
+      tags "Content Blocks"
+      produces "application/json"
+
+      response "200", "blocks found" do
+        run_test!
+      end
+    end
+  end
+end

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -18,11 +18,10 @@ RSpec.describe "API" do
 
       tags "Content Blocks"
       produces "application/json"
-      parameter name: "block_type", in: :query, type: :string
-      parameter name: "lead_organisation_id", in: :query, type: :string
 
-      let(:block_type) { nil }
-      let(:lead_organisation_id) { nil }
+      parameter name: "block_type", in: :query, type: :string, required: false
+      parameter name: "lead_organisation_id", in: :query, type: :string, required: false
+      parameter name: "keyword", in: :query, type: :string, required: false
 
       response "200", "blocks found" do
         before do
@@ -79,6 +78,21 @@ RSpec.describe "API" do
           expect(data.size).to eq(1)
           expect(data.first["organisation"]["name"]).to eq(organisations.first.name)
           expect(data.first["organisation"]["content_id"]).to eq(organisations.first.id)
+        end
+      end
+
+      response "200", "filters by keyword", document: false do
+        before do
+          create(:edition, :published, document: create(:document), lead_organisation_id: organisations.first.id, title: "first")
+          create(:edition, :published, document: create(:document), lead_organisation_id: organisations.first.id, title: "second")
+        end
+
+        let(:keyword) { "first" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data.size).to eq(1)
+          expect(data.first["title"]).to eq("first")
         end
       end
     end

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -19,33 +19,57 @@ RSpec.describe "API" do
       tags "Content Blocks"
       produces "application/json"
 
-      parameter name: "block_type", in: :query, type: :string, required: false
-      parameter name: "lead_organisation_id", in: :query, type: :string, required: false
-      parameter name: "keyword", in: :query, type: :string, required: false
+      parameter name: "block_type", in: :query, type: :string, required: false, description: "The type of block to filter by. This is a case-insensitive match against the block type defined in the document associated with the content block."
+      parameter name: "lead_organisation_id", in: :query, type: :string, required: false, description: "The Content ID of the lead organisation to filter by."
+      parameter name: "keyword", in: :query, type: :string, required: false, description: "The keyword to filter by. Searches against the title and the details hash of the content block."
+      parameter name: "page", in: :query, type: :string, required: false, description: "The page number to return. Defaults to 1."
+
+      # Overrides the `page` method included in all request specs in spec/support/capybara.rb to prevent it from being
+      # called when the `page` parameter is used in the tests
+      let(:page) { nil }
 
       response "200", "blocks found" do
         before do
           create(:edition, :published, document: create(:document), lead_organisation_id: organisations.first.id)
         end
 
-        schema type: :array, items: {
-          type: :object,
-          additionalProperties: false,
-          properties: {
-            title: { type: :string },
-            block_type: { type: :string },
-            organisation: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                content_id: { type: :string },
-              },
-            },
-            state: { type: :string, enum: %w[published] },
-            embed_code: { type: :string },
-            formats: { type: :array, items: { type: :string } },
-          },
-        }
+        schema type: :object,
+               additionalProperties: false,
+               properties: {
+                 total: { type: :integer },
+                 pages: { type: :integer },
+                 current_page: { type: :integer },
+                 links: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       href: { type: :string },
+                       rel: { type: :string, enum: %w[self next previous] },
+                     },
+                   },
+                 },
+                 results: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       title: { type: :string },
+                       block_type: { type: :string },
+                       organisation: {
+                         type: :object,
+                         properties: {
+                           name: { type: :string },
+                           content_id: { type: :string },
+                         },
+                       },
+                       state: { type: :string, enum: %w[published] },
+                       embed_code: { type: :string },
+                       formats: { type: :array, items: { type: :string } },
+                     },
+                   },
+                 },
+               }
         run_test!
       end
 
@@ -59,8 +83,16 @@ RSpec.describe "API" do
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data.size).to eq(1)
-          expect(data.first["block_type"]).to eq("Pension")
+          it_returns_correct_pagination_information(
+            data,
+            total: 1,
+            pages: 1,
+            current_page: 1,
+            expected_links: [{ rel: "self", href: "http://www.example.com/api/blocks/search?block_type=pension&page=1" }],
+          )
+
+          expect(data["results"].size).to eq(1)
+          expect(data["results"].first["block_type"]).to eq("Pension")
         end
       end
 
@@ -75,9 +107,17 @@ RSpec.describe "API" do
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data.size).to eq(1)
-          expect(data.first["organisation"]["name"]).to eq(organisations.first.name)
-          expect(data.first["organisation"]["content_id"]).to eq(organisations.first.id)
+          it_returns_correct_pagination_information(
+            data,
+            total: 1,
+            pages: 1,
+            current_page: 1,
+            expected_links: [{ rel: "self", href: "http://www.example.com/api/blocks/search?lead_organisation_id=#{lead_organisation_id}&page=1" }],
+          )
+
+          expect(data["results"].size).to eq(1)
+          expect(data["results"].first["organisation"]["name"]).to eq(organisations.first.name)
+          expect(data["results"].first["organisation"]["content_id"]).to eq(organisations.first.id)
         end
       end
 
@@ -91,10 +131,92 @@ RSpec.describe "API" do
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data.size).to eq(1)
-          expect(data.first["title"]).to eq("first")
+          it_returns_correct_pagination_information(
+            data,
+            total: 1,
+            pages: 1,
+            current_page: 1,
+            expected_links: [{ rel: "self", href: "http://www.example.com/api/blocks/search?keyword=first&page=1" }],
+          )
+
+          expect(data["results"].size).to eq(1)
+          expect(data["results"].first["title"]).to eq("first")
         end
       end
+
+      context "pagination" do
+        before do
+          # Stub the default page size to 1 so that we can test pagination with a small number of records
+          stub_const("ContentBlock::Query::DEFAULT_PAGE_SIZE", 1)
+          create_list(:edition, 3, :published, document: create(:document), lead_organisation_id: organisations.first.id)
+        end
+
+        response "200", "returns the first page", document: false do
+          let(:page) { 1 }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            it_returns_correct_pagination_information(
+              data,
+              total: 3,
+              pages: 3,
+              current_page: 1,
+              expected_links: [
+                { rel: "next", href: "http://www.example.com/api/blocks/search?page=2" },
+                { rel: "self", href: "http://www.example.com/api/blocks/search?page=1" },
+              ],
+            )
+          end
+        end
+
+        response "200", "returns the second page", document: false do
+          let(:page) { 2 }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            it_returns_correct_pagination_information(
+              data,
+              total: 3,
+              pages: 3,
+              current_page: 2,
+              expected_links: [
+                { rel: "previous", href: "http://www.example.com/api/blocks/search?page=1" },
+                { rel: "next", href: "http://www.example.com/api/blocks/search?page=3" },
+                { rel: "self", href: "http://www.example.com/api/blocks/search?page=2" },
+              ],
+            )
+          end
+        end
+
+        response "200", "returns the last page", document: false do
+          let(:page) { 3 }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            it_returns_correct_pagination_information(
+              data,
+              total: 3,
+              pages: 3,
+              current_page: 3,
+              expected_links: [
+                { rel: "previous", href: "http://www.example.com/api/blocks/search?page=2" },
+                { rel: "self", href: "http://www.example.com/api/blocks/search?page=3" },
+              ],
+            )
+          end
+        end
+      end
+    end
+  end
+
+  def it_returns_correct_pagination_information(data, total:, pages:, current_page:, expected_links:)
+    expect(data["total"]).to eq(total)
+    expect(data["pages"]).to eq(pages)
+    expect(data["current_page"]).to eq(current_page)
+    expect(data["links"].size).to eq(expected_links.size)
+    expected_links.each_with_index do |link, index|
+      expect(data["links"][index]["rel"]).to eq(link[:rel])
+      expect(data["links"][index]["href"]).to eq(link[:href])
     end
   end
 end

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -2,15 +2,25 @@ require "swagger_helper"
 
 RSpec.describe "API" do
   path "/blocks/search" do
-    get "Search content blocks" do
+    before do
+      organisation = build(:organisation)
+      allow_any_instance_of(Edition).to receive(:lead_organisation).and_return(organisation)
+    end
+
+    get "Search for content blocks" do
+      description <<~DESC
+        This endpoint allows you to search for content blocks. You can filter by block type, lead organisation, and
+        keyword, and the results are paginated.
+      DESC
+
       tags "Content Blocks"
       produces "application/json"
+      parameter name: "block_type", in: :query, type: :string
+      let(:block_type) { nil }
 
       response "200", "blocks found" do
         before do
-          organisation = build(:organisation)
           create(:edition, :published, document: create(:document))
-          allow_any_instance_of(Edition).to receive(:lead_organisation).and_return(organisation)
         end
 
         schema type: :array, items: {
@@ -32,6 +42,21 @@ RSpec.describe "API" do
           },
         }
         run_test!
+      end
+
+      response "200", "filters by block type", document: false do
+        before do
+          create(:edition, :published, document: create(:document, block_type: "pension"))
+          create(:edition, :published, document: create(:document, block_type: "contact"))
+        end
+
+        let(:block_type) { "pension" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data.size).to eq(1)
+          expect(data.first["block_type"]).to eq("Pension")
+        end
       end
     end
   end

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -7,6 +7,30 @@ RSpec.describe "API" do
       produces "application/json"
 
       response "200", "blocks found" do
+        before do
+          organisation = build(:organisation)
+          create(:edition, :published, document: create(:document))
+          allow_any_instance_of(Edition).to receive(:lead_organisation).and_return(organisation)
+        end
+
+        schema type: :array, items: {
+          type: :object,
+          additionalProperties: false,
+          properties: {
+            title: { type: :string },
+            block_type: { type: :string },
+            organisation: {
+              type: :object,
+              properties: {
+                name: { type: :string },
+                content_id: { type: :string },
+              },
+            },
+            state: { type: :string, enum: %w[published] },
+            embed_code: { type: :string },
+            formats: { type: :array, items: { type: :string } },
+          },
+        }
         run_test!
       end
     end

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -2,9 +2,12 @@ require "swagger_helper"
 
 RSpec.describe "API" do
   path "/blocks/search" do
+    let(:organisations) do
+      build_list(:organisation, 3)
+    end
+
     before do
-      organisation = build(:organisation)
-      allow_any_instance_of(Edition).to receive(:lead_organisation).and_return(organisation)
+      allow(Organisation).to receive(:all).and_return(organisations)
     end
 
     get "Search for content blocks" do
@@ -16,11 +19,14 @@ RSpec.describe "API" do
       tags "Content Blocks"
       produces "application/json"
       parameter name: "block_type", in: :query, type: :string
+      parameter name: "lead_organisation_id", in: :query, type: :string
+
       let(:block_type) { nil }
+      let(:lead_organisation_id) { nil }
 
       response "200", "blocks found" do
         before do
-          create(:edition, :published, document: create(:document))
+          create(:edition, :published, document: create(:document), lead_organisation_id: organisations.first.id)
         end
 
         schema type: :array, items: {
@@ -46,8 +52,8 @@ RSpec.describe "API" do
 
       response "200", "filters by block type", document: false do
         before do
-          create(:edition, :published, document: create(:document, block_type: "pension"))
-          create(:edition, :published, document: create(:document, block_type: "contact"))
+          create(:edition, :published, document: create(:document, block_type: "pension"), lead_organisation_id: organisations.first.id)
+          create(:edition, :published, document: create(:document, block_type: "contact"), lead_organisation_id: organisations.first.id)
         end
 
         let(:block_type) { "pension" }
@@ -56,6 +62,23 @@ RSpec.describe "API" do
           data = JSON.parse(response.body)
           expect(data.size).to eq(1)
           expect(data.first["block_type"]).to eq("Pension")
+        end
+      end
+
+      response "200", "filters by organisation", document: false do
+        before do
+          organisations.each do |org|
+            create(:edition, :published, document: create(:document), lead_organisation_id: org.id)
+          end
+        end
+
+        let(:lead_organisation_id) { organisations.first.id }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data.size).to eq(1)
+          expect(data.first["organisation"]["name"]).to eq(organisations.first.name)
+          expect(data.first["organisation"]["content_id"]).to eq(organisations.first.id)
         end
       end
     end

--- a/engines/api/spec/unit/presenters/api/block_presenter_spec.rb
+++ b/engines/api/spec/unit/presenters/api/block_presenter_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Api::BlockPresenter do
+  describe ".present" do
+    it "serializes a content block into the public API shape" do
+      lead_org = build(:organisation)
+      block = build(:content_block)
+      allow(block).to receive(:lead_organisation).and_return(lead_org)
+
+      result = described_class.present(block)
+
+      expect(result).to include(
+        title: block.title,
+        block_type: block.block_type,
+        state: "published",
+        embed_code: block.embed_code,
+        formats: block.formats,
+      )
+
+      expect(result[:organisation]).to eq(
+        name: lead_org.name,
+        content_id: lead_org.id,
+      )
+    end
+  end
+
+  describe ".present_collection" do
+    it "serializes all blocks in order" do
+      org1 = build(:organisation, name: "Org 1")
+      org2 = build(:organisation, name: "Org 2")
+
+      block1 = build(:content_block)
+      block2 = build(:content_block)
+
+      allow(block1).to receive(:lead_organisation).and_return(org1)
+      allow(block2).to receive(:lead_organisation).and_return(org2)
+
+      blocks = [block1, block2]
+
+      result = described_class.present_collection(blocks)
+
+      expect(result.size).to eq(2)
+      expect(result[0][:title]).to eq(blocks[0].title)
+      expect(result[1][:title]).to eq(blocks[1].title)
+
+      expect(result[0][:organisation]).to eq(name: org1.name, content_id: org1.id)
+      expect(result[1][:organisation]).to eq(name: org2.name, content_id: org2.id)
+    end
+
+    it "returns an empty array for no blocks" do
+      expect(described_class.present_collection([])).to eq([])
+    end
+  end
+end

--- a/engines/api/spec/unit/presenters/api/results_presenter_spec.rb
+++ b/engines/api/spec/unit/presenters/api/results_presenter_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe Api::ResultsPresenter do
+  describe "#present" do
+    let(:blocks) { [double("block")] }
+
+    before do
+      allow(Api::BlockPresenter).to receive(:present_collection).with(blocks).and_return([:presented])
+    end
+
+    context "on the first page" do
+      let(:result) { double(total_count: 10, total_pages: 3, current_page: 1, blocks: blocks) }
+      let(:request_url) { "https://example.com/api/blocks?foo=bar&page=1" }
+      subject { described_class.present(result, request_url) }
+
+      it "includes pagination fields and results" do
+        expect(subject).to include(total: 10, pages: 3, current_page: 1)
+        expect(subject[:results]).to eq([:presented])
+      end
+
+      it "includes next and self links (no previous)" do
+        links = subject[:links]
+        expect(links.map { |l| l[:rel] }).to eq(%w[next self])
+
+        next_link = links.find { |l| l[:rel] == "next" }
+        self_link = links.find { |l| l[:rel] == "self" }
+
+        expect(next_link[:href]).to eq("https://example.com/api/blocks?foo=bar&page=2")
+        expect(self_link[:href]).to eq("https://example.com/api/blocks?foo=bar&page=1")
+      end
+    end
+
+    context "on a middle page" do
+      let(:result) { double(total_count: 10, total_pages: 3, current_page: 2, blocks: blocks) }
+      let(:request_url) { "https://example.com/api/blocks?foo=bar&page=2" }
+      subject { described_class.present(result, request_url) }
+
+      it "includes previous, next and self links in that order" do
+        rels = subject[:links].map { |l| l[:rel] }
+        expect(rels).to eq(%w[previous next self])
+
+        prev = subject[:links].find { |l| l[:rel] == "previous" }
+        nxt = subject[:links].find { |l| l[:rel] == "next" }
+
+        expect(prev[:href]).to eq("https://example.com/api/blocks?foo=bar&page=1")
+        expect(nxt[:href]).to eq("https://example.com/api/blocks?foo=bar&page=3")
+      end
+    end
+
+    context "on the last page" do
+      let(:result) { double(total_count: 10, total_pages: 3, current_page: 3, blocks: blocks) }
+      let(:request_url) { "https://example.com/api/blocks?foo=bar&page=3" }
+      subject { described_class.present(result, request_url) }
+
+      it "includes previous and self links (no next)" do
+        rels = subject[:links].map { |l| l[:rel] }
+        expect(rels).to eq(%w[previous self])
+
+        prev = subject[:links].find { |l| l[:rel] == "previous" }
+        self_link = subject[:links].find { |l| l[:rel] == "self" }
+
+        expect(prev[:href]).to eq("https://example.com/api/blocks?foo=bar&page=2")
+        expect(self_link[:href]).to eq("https://example.com/api/blocks?foo=bar&page=3")
+      end
+    end
+
+    context "when request_url has no page param" do
+      let(:result) { double(total_count: 10, total_pages: 3, current_page: 1, blocks: blocks) }
+      let(:request_url) { "https://example.com/api/blocks?foo=bar" }
+      subject { described_class.present(result, request_url) }
+
+      it "appends page param with an ampersand" do
+        rels = subject[:links].map { |l| l[:rel] }
+        expect(rels).to eq(%w[next self])
+
+        expect(subject[:links].find { |l| l[:rel] == "next" }[:href]).to eq("https://example.com/api/blocks?foo=bar&page=2")
+        expect(subject[:links].find { |l| l[:rel] == "self" }[:href]).to eq("https://example.com/api/blocks?foo=bar&page=1")
+      end
+    end
+
+    context "when there is only one page" do
+      let(:result) { double(total_count: 2, total_pages: 1, current_page: 1, blocks: blocks) }
+      let(:request_url) { "https://example.com/api/blocks?foo=bar&page=1" }
+      subject { described_class.present(result, request_url) }
+
+      it "only exposes the self link" do
+        rels = subject[:links].map { |l| l[:rel] }
+        expect(rels).to eq(%w[self])
+        expect(subject[:links].first[:href]).to eq("https://example.com/api/blocks?foo=bar&page=1")
+      end
+    end
+  end
+end

--- a/engines/api/swagger/v1/swagger.yaml
+++ b/engines/api/swagger/v1/swagger.yaml
@@ -1,0 +1,145 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Content Block Manager API",
+    "version": "v1",
+    "description": "The Content Block Manager API allows users to view information about content blocks. It is largely designed\nfor use by the [authoring widget](https://github.com/alphagov/content-block-editor) to allow preview and\nsearch of content blocks.\n\nCurrently, only search is supported, but in the future, we plan to support rendering of content blocks.\n\nAt the moment, the API is read-only, and only supports searching for published content blocks, but in the\nfuture, we may add support for draft content blocks and for creating and updating content blocks, which will\nrequire authentication.\n"
+  },
+  "paths": {
+    "/blocks/search": {
+      "get": {
+        "summary": "Search for content blocks",
+        "description": "This endpoint allows you to search for content blocks. You can filter by block type, lead organisation, and\nkeyword, and the results are paginated.\n",
+        "tags": [
+          "Content Blocks"
+        ],
+        "parameters": [
+          {
+            "name": "block_type",
+            "in": "query",
+            "required": false,
+            "description": "The type of block to filter by. This is a case-insensitive match against the block type defined in the document associated with the content block.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lead_organisation_id",
+            "in": "query",
+            "required": false,
+            "description": "The Content ID of the lead organisation to filter by.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": false,
+            "description": "The keyword to filter by. Searches against the title and the details hash of the content block.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "The page number to return. Defaults to 1.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "blocks found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "pages": {
+                      "type": "integer"
+                    },
+                    "current_page": {
+                      "type": "integer"
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "href": {
+                            "type": "string"
+                          },
+                          "rel": {
+                            "type": "string",
+                            "enum": [
+                              "self",
+                              "next",
+                              "previous"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "block_type": {
+                            "type": "string"
+                          },
+                          "organisation": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "content_id": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "published"
+                            ]
+                          },
+                          "embed_code": {
+                            "type": "string"
+                          },
+                          "formats": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://content-block-manager.publishing.service.gov.uk/api"
+    }
+  ]
+}

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -63,4 +63,4 @@ end
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
 # Require step definitions contained within engines
-Dir.glob(Rails.root.join("engines/**/features/step_definitions/*.rb")).each(&method(:require))
+Dir.glob(Rails.root.join("engines/**/features/**/step_definitions/*.rb")).each(&method(:require))

--- a/packwerk.yml
+++ b/packwerk.yml
@@ -1,2 +1,7 @@
 require:
   - packwerk-extensions
+exclude:
+  - '**/*_steps.rb' # Ignore any code used in Cucumber steps
+  - '**/*_spec.rb' # Ignore any code used in RSpec tests
+  - 'vendor/**/*' # Ignore any third-party code
+  - 'tmp/**/*' # Ignore anything in the tmp directory

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join("engines/api/swagger").to_s
+
+  config.openapi_specs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "Content Block Manager API",
+        version: "v1",
+        description: <<~DESC,
+          The Content Block Manager API allows users to view information about content blocks. It is largely designed
+          for use by the [authoring widget](https://github.com/alphagov/content-block-editor) to allow preview and
+          search of content blocks.
+
+          Currently, only search is supported, but in the future, we plan to support rendering of content blocks.
+
+          At the moment, the API is read-only, and only supports searching for published content blocks, but in the
+          future, we may add support for draft content blocks and for creating and updating content blocks, which will
+          require authentication.
+        DESC
+      },
+      paths: {},
+      servers: [
+        {
+          url: "#{Plek.new('publishing.service.gov.uk').find('content-block-manager')}/api",
+        },
+      ],
+    },
+  }
+end

--- a/spec/unit/app/public/content_block_spec.rb
+++ b/spec/unit/app/public/content_block_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe ContentBlock do
   it { should delegate_method(:document).to(:edition) }
   it { should delegate_method(:auth_bypass_id).to(:edition) }
   it { should delegate_method(:content_id).to(:edition) }
+  it { should delegate_method(:lead_organisation).to(:edition) }
   it { should delegate_method(:render).to(:edition) }
   it { should delegate_method(:schema).to(:document) }
+  it { should delegate_method(:embed_code).to(:document) }
+  it { should delegate_method(:formats).to(:schema) }
 
   describe ".from_content_id_alias" do
     it "returns a content block object" do

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe ContentBlock::Query do
+  describe ".call" do
+    it "returns one content block per document" do
+      doc_a = create(:document)
+      create(:edition, :published, document: doc_a, updated_at: 2.days.ago, title: "Doc A old edition")
+      create(:edition, :published, document: doc_a, updated_at: 1.day.ago, title: "Doc A new edition")
+
+      doc_b = create(:document)
+      create(:edition, :published, document: doc_b, updated_at: Time.current, title: "Doc B new edition")
+
+      excluded_document = create(:document)
+      create(:edition, :draft, document: excluded_document, updated_at: Time.current)
+
+      result = described_class.call
+
+      expect(result).to all(be_a(ContentBlock))
+
+      expect(result.size).to eq(2)
+      expect(result.first.title).to eq("Doc A new edition")
+      expect(result.second.title).to eq("Doc B new edition")
+    end
+  end
+end

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -19,5 +19,18 @@ RSpec.describe ContentBlock::Query do
       expect(result.first.title).to eq("Doc A new edition")
       expect(result.second.title).to eq("Doc B new edition")
     end
+
+    it "filters by block type" do
+      pension_doc = create(:document, block_type: "pension")
+      create(:edition, :published, document: pension_doc, title: "Pension")
+
+      contact_doc = create(:document, block_type: "contact")
+      create(:edition, :published, document: contact_doc, title: "Contact")
+
+      result = described_class.call(block_type: "pension")
+
+      expect(result.size).to eq(1)
+      expect(result.first.title).to eq("Pension")
+    end
   end
 end

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -67,5 +67,24 @@ RSpec.describe ContentBlock::Query do
       expect(result.size).to eq(1)
       expect(result.first.title).to eq("first")
     end
+
+    it "supports pagination" do
+      15.times do |i|
+        document = create(:document)
+        create(:edition, :published, document:, title: "Doc #{i + 1}", created_at: i.days.ago)
+      end
+
+      page_1_result = described_class.call(page: 1)
+
+      expect(page_1_result.size).to eq(10)
+      expect(page_1_result.first.title).to eq("Doc 1")
+      expect(page_1_result.last.title).to eq("Doc 10")
+
+      page_2_result = described_class.call(page: 2)
+
+      expect(page_2_result.size).to eq(5)
+      expect(page_2_result.first.title).to eq("Doc 11")
+      expect(page_2_result.last.title).to eq("Doc 15")
+    end
   end
 end

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -13,11 +13,15 @@ RSpec.describe ContentBlock::Query do
 
       result = described_class.call
 
-      expect(result).to all(be_a(ContentBlock))
+      expect(result.current_page).to eq(1)
+      expect(result.total_pages).to eq(1)
+      expect(result.total_count).to eq(2)
 
-      expect(result.size).to eq(2)
-      expect(result.first.title).to eq("Doc A new edition")
-      expect(result.second.title).to eq("Doc B new edition")
+      expect(result.blocks).to all(be_a(ContentBlock))
+
+      expect(result.blocks.size).to eq(2)
+      expect(result.blocks.first.title).to eq("Doc A new edition")
+      expect(result.blocks.second.title).to eq("Doc B new edition")
     end
 
     it "filters by block type" do
@@ -29,8 +33,8 @@ RSpec.describe ContentBlock::Query do
 
       result = described_class.call(block_type: "pension")
 
-      expect(result.size).to eq(1)
-      expect(result.first.title).to eq("Pension")
+      expect(result.blocks.size).to eq(1)
+      expect(result.blocks.first.title).to eq("Pension")
     end
 
     it "filters by organisation" do
@@ -46,8 +50,8 @@ RSpec.describe ContentBlock::Query do
 
       result = described_class.call(lead_organisation_id: org_1_edition.lead_organisation_id)
 
-      expect(result.size).to eq(1)
-      expect(result.first.lead_organisation.id).to eq(org_1_edition.lead_organisation_id)
+      expect(result.blocks.size).to eq(1)
+      expect(result.blocks.first.lead_organisation.id).to eq(org_1_edition.lead_organisation_id)
     end
 
     it "filters by keyword" do
@@ -64,8 +68,8 @@ RSpec.describe ContentBlock::Query do
 
       result = described_class.call(keyword: "keyword")
 
-      expect(result.size).to eq(1)
-      expect(result.first.title).to eq("first")
+      expect(result.blocks.size).to eq(1)
+      expect(result.blocks.first.title).to eq("first")
     end
 
     it "supports pagination" do
@@ -76,15 +80,23 @@ RSpec.describe ContentBlock::Query do
 
       page_1_result = described_class.call(page: 1)
 
-      expect(page_1_result.size).to eq(10)
-      expect(page_1_result.first.title).to eq("Doc 1")
-      expect(page_1_result.last.title).to eq("Doc 10")
+      expect(page_1_result.current_page).to eq(1)
+      expect(page_1_result.total_pages).to eq(2)
+      expect(page_1_result.total_count).to eq(15)
+
+      expect(page_1_result.blocks.size).to eq(10)
+      expect(page_1_result.blocks.first.title).to eq("Doc 1")
+      expect(page_1_result.blocks.last.title).to eq("Doc 10")
 
       page_2_result = described_class.call(page: 2)
 
-      expect(page_2_result.size).to eq(5)
-      expect(page_2_result.first.title).to eq("Doc 11")
-      expect(page_2_result.last.title).to eq("Doc 15")
+      expect(page_2_result.current_page).to eq(2)
+      expect(page_2_result.total_pages).to eq(2)
+      expect(page_2_result.total_count).to eq(15)
+
+      expect(page_2_result.blocks.size).to eq(5)
+      expect(page_2_result.blocks.first.title).to eq("Doc 11")
+      expect(page_2_result.blocks.last.title).to eq("Doc 15")
     end
   end
 end

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -32,5 +32,22 @@ RSpec.describe ContentBlock::Query do
       expect(result.size).to eq(1)
       expect(result.first.title).to eq("Pension")
     end
+
+    it "filters by organisation" do
+      organisations = [
+        build(:organisation, id: SecureRandom.uuid, name: "Org 1"),
+        build(:organisation, id: SecureRandom.uuid, name: "Org 2"),
+      ]
+
+      allow(Organisation).to receive(:all).and_return(organisations)
+
+      org_1_edition = create(:edition, :published, document: create(:document), lead_organisation_id: organisations[0].id)
+      _org_2_edition = create(:edition, :published, document: create(:document), lead_organisation_id: organisations[1].id)
+
+      result = described_class.call(lead_organisation_id: org_1_edition.lead_organisation_id)
+
+      expect(result.size).to eq(1)
+      expect(result.first.lead_organisation.id).to eq(org_1_edition.lead_organisation_id)
+    end
   end
 end

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -49,5 +49,23 @@ RSpec.describe ContentBlock::Query do
       expect(result.size).to eq(1)
       expect(result.first.lead_organisation.id).to eq(org_1_edition.lead_organisation_id)
     end
+
+    it "filters by keyword" do
+      document_with_first_keyword = create(:document)
+      _edition_with_first_keyword = create(:edition,
+                                           :published,
+                                           document: document_with_first_keyword,
+                                           title: "first")
+      document_without_first_keyword = create(:document)
+      _edition_without_first_keyword = create(:edition, :published, document: document_without_first_keyword,
+                                                                    title: "second")
+
+      allow(Document).to receive(:with_keyword).and_return([document_with_first_keyword])
+
+      result = described_class.call(keyword: "keyword")
+
+      expect(result.size).to eq(1)
+      expect(result.first.title).to eq("first")
+    end
   end
 end


### PR DESCRIPTION
This adds a new search endpoint to allow users to search for content blocks by a number of criteria. I've used [Rswag](https://github.com/rswag/rswag) to generate documentation based on our Rspec tests. There's quite a few commits here, but I've tried to build up the functionality bit by bit, so most of the commits should be fairly small.