### PR TITLE
(Fix) Add specific ordering to API query

### DIFF
--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -40,6 +40,11 @@ class ContentBlock
               .by_block_type(filters[:block_type])
               .by_lead_organisation_id(filters[:lead_organisation_id])
               .by_keyword(filters[:keyword])
+              .order(sort_order)
+    end
+
+    def sort_order
+      "editions.created_at DESC"
     end
 
     module Scopes

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ContentBlock::Query do
       expect(result.blocks.first.title).to eq("first")
     end
 
-    it "supports pagination" do
+    it "returns paginated results ordered by newest edition first" do
       15.times do |i|
         document = create(:document)
         create(:edition, :published, document:, title: "Doc #{i + 1}", created_at: i.days.ago)


### PR DESCRIPTION
At the moment, the query sorts results in a non-deterministic order, which means the tests sometimes fail. This adds a specific `sort_order` to the query to ensure that results are always ordered in the same way.

I’ve also updated the spec description to be more specific about the expectation.