### PR TITLE
API engine missing from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV JWT_AUTH_SECRET=unused_yet_required
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
-COPY engines/fact_check ./engines/fact_check
-COPY engines/block_preview ./engines/block_preview
+COPY engines ./engines
 RUN bundle install
 COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates


### PR DESCRIPTION
This just ensures that the directory is available in docker so that it can be used.

Currently failing the build : https://github.com/alphagov/content-block-manager/actions/runs/26160252231/job/76949999382