### PR TITLE
(CM-936) Content design error message tweaks

### DIFF
--- a/app/controllers/concerns/date_range_validator.rb
+++ b/app/controllers/concerns/date_range_validator.rb
@@ -1,5 +1,6 @@
 class DateRangeValidator
   SUBSCHEMA_BLOCK_TYPE = "date_range".freeze
+  include ApplicationHelper
 
   def initialize(edition, object_params)
     @edition = edition
@@ -52,13 +53,17 @@ private
       I18n.t(
         "activerecord.errors.models.edition.attributes.#{field_name}.blank",
         attribute: attribute,
-        default: I18n.t("activerecord.errors.models.edition.blank", attribute: attribute),
+        default: I18n.t("activerecord.errors.models.edition.blank",
+                        attribute: attribute,
+                        attribute_with_indefinite_article: add_indefinite_article(attribute)),
       )
     when :date_invalid
       I18n.t(
         "activerecord.errors.models.edition.attributes.#{field_name}.invalid",
         attribute: attribute,
-        default: I18n.t("activerecord.errors.models.edition.invalid", attribute: attribute),
+        default: I18n.t("activerecord.errors.models.edition.invalid",
+                        attribute: attribute,
+                        attribute_with_indefinite_article: add_indefinite_article(attribute)),
       )
     end
   end

--- a/app/models/concerns/schema/field/translations.rb
+++ b/app/models/concerns/schema/field/translations.rb
@@ -1,6 +1,8 @@
 class Schema::Field
   module Translations
     extend ActiveSupport::Concern
+    include ApplicationHelper
+
     included do
       def label
         I18n.t(translation_lookup_path("labels"), default: default_translation_value)
@@ -20,7 +22,15 @@ class Schema::Field
           translation_lookup_path("attributes"),
           error_type,
         ].join(".")
-        default = I18n.t("activerecord.errors.models.edition.#{error_type}", attribute: label, **args)
+        # If the translated label is a hash, this means this field has nested fields, so we use the `title` as the attribute instead
+        attribute = label.is_a?(String) ? label.downcase : title.downcase
+
+        default = I18n.t(
+          "activerecord.errors.models.edition.#{error_type}",
+          attribute:,
+          attribute_with_indefinite_article: add_indefinite_article(attribute),
+          **args,
+        )
         I18n.t(path, default:, **args)
       end
 

--- a/app/models/concerns/schema/field/translations.rb
+++ b/app/models/concerns/schema/field/translations.rb
@@ -14,6 +14,16 @@ class Schema::Field
         I18n.t(translation_lookup_path("hints"), default: nil)
       end
 
+      def error_message(error_type, **args)
+        path = [
+          "activerecord.errors.models",
+          translation_lookup_path("attributes"),
+          error_type,
+        ].join(".")
+        default = I18n.t("activerecord.errors.models.edition.#{error_type}", attribute: label, **args)
+        I18n.t(path, default:, **args)
+      end
+
     private
 
       def default_translation_value

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,4 +1,6 @@
 class Document < ApplicationRecord
+  include ApplicationHelper
+
   include Scopes::SearchableByKeyword
   include Scopes::SearchableByLeadOrganisation
   include Scopes::SearchableByUpdatedDate
@@ -63,6 +65,15 @@ class Document < ApplicationRecord
     @schema ||= Schema.find_by_block_type(block_type)
   end
 
+  def title_name
+    attribute_key = "activerecord.attributes.edition/document.title.#{block_type || 'default'}"
+    I18n.t(attribute_key, default: I18n.t("activerecord.attributes.edition/document.title.default"))
+  end
+
+  def title_name_with_indefinite_article
+    add_indefinite_article(title_name.downcase)
+  end
+
 private
 
   def embed_code_prefix
@@ -71,7 +82,7 @@ private
 
   def sluggable_string_contains_alphanumeric_chars
     if sluggable_string !~ /[a-z0-9]+/i
-      errors.add(:title, I18n.t("document.index.errors.title.missing_valid_chars"))
+      errors.add(:title, I18n.t("activerecord.errors.models.document.attributes.title.missing_valid_chars", attribute: title_name))
     end
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,5 +1,10 @@
 class Edition < ApplicationRecord
-  validates :title, presence: true
+  validates :title, presence: {
+    message: lambda do |edition, _|
+      I18n.t("activerecord.errors.models.edition.blank",
+             attribute_with_indefinite_article: edition.document.title_name_with_indefinite_article)
+    end,
+  }
   validates :change_note, presence: true, if: :major_change?, on: :change_note
   validates :major_change, inclusion: [true, false], on: :change_note
 

--- a/app/public/models/schema.rb
+++ b/app/public/models/schema.rb
@@ -66,6 +66,20 @@ class Schema
     fields.find(proc { raise "Field '#{name}' not found" }) { |f| f.name == name }
   end
 
+  def all_fields
+    collected = fields.dup
+
+    subschemas.each do |subschema|
+      collected.concat(subschema.all_fields)
+    end
+
+    fields.each do |field|
+      collected.concat(field.all_nested_fields)
+    end
+
+    collected
+  end
+
   def subschema(name)
     subschemas.find { |s| s.id == name }
   end

--- a/app/public/models/schema/field.rb
+++ b/app/public/models/schema/field.rb
@@ -49,6 +49,18 @@ class Schema
       end
     end
 
+    def all_nested_fields
+      return [] if nested_fields.nil?
+
+      collected = nested_fields.dup
+
+      nested_fields.each do |field|
+        collected.concat(field.nested_fields) if field.nested_fields.present?
+      end
+
+      collected
+    end
+
     def nested_field(nested_field_name)
       raise(ArgumentError, "Provide the name of a nested field") if nested_field_name.blank?
 

--- a/app/validators/details_validator.rb
+++ b/app/validators/details_validator.rb
@@ -61,12 +61,6 @@ class DetailsValidator < ActiveModel::Validator
     )
   end
 
-  def get_attribute_and_key_from_error(error)
-    data_pointer = error["data_pointer"].delete_prefix("/")
-    field_items = data_pointer.split("/")
-    [field_items.last, key_with_optional_prefix(error, nil)]
-  end
-
   def validate_with_schema(edition)
     # Fetch the details and remove any blank fields (JSONSchema classes an empty string as valid,
     # unless a specific format has been specified)
@@ -90,16 +84,6 @@ class DetailsValidator < ActiveModel::Validator
     else
       key
     end
-  end
-
-  def translate_error(type, attribute, **args)
-    default = "activerecord.errors.models.edition.#{type}".to_sym
-    I18n.t(
-      "activerecord.errors.models.edition.attributes.#{attribute}.#{type}",
-      attribute: attribute.humanize,
-      default: [default],
-      **args,
-    )
   end
 
 private

--- a/app/validators/details_validator.rb
+++ b/app/validators/details_validator.rb
@@ -26,18 +26,18 @@ class DetailsValidator < ActiveModel::Validator
       key = key_with_optional_prefix(error, k)
       edition.errors.add(
         "details_#{key}",
-        translate_error("blank", k),
+        error_message_for_key(key, "blank"),
       )
     end
   end
 
   def add_format_minimum_errors(error, block_type)
-    attribute, key = get_attribute_and_key_from_error(error)
+    key = key_with_optional_prefix(error, nil)
     minimum_date = resolve_format_minimum_date(error["schema"]["formatMinimum"], block_type)
 
     edition.errors.add(
       "details_#{key}",
-      translate_error("minimum", attribute, minimum_date: minimum_date),
+      error_message_for_key(key, "minimum", minimum_date: minimum_date),
     )
   end
 
@@ -53,10 +53,11 @@ class DetailsValidator < ActiveModel::Validator
   end
 
   def add_format_errors(error)
-    attribute, key = get_attribute_and_key_from_error(error)
+    key = key_with_optional_prefix(error, nil)
+
     edition.errors.add(
       "details_#{key}",
-      translate_error("invalid", attribute),
+      error_message_for_key(key, "invalid"),
     )
   end
 
@@ -130,5 +131,16 @@ private
     object.compact_blank!
     object.each { |o| compact_nested(o) }
     object
+  end
+
+  def error_message_for_key(key, type, **args)
+    field = field_for_key(key)
+    field&.error_message(type, **args)
+  end
+
+  def field_for_key(key)
+    # Remove the index from the key if present, e.g. "details_1_title" becomes "details_title"
+    id_attribute = "edition_details_#{key.gsub(/_([0-9]+)_/, '_')}"
+    edition.schema.all_fields.find { |f| f.id_attribute == id_attribute }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
           title:
             not_unique: "A content block with the same title already exists. If you continue, this block will not have a unique title."
           format: "%{message}"
-          invalid: "Invalid %{attribute}"
-          blank: "%{attribute} cannot be blank"
+          invalid: "Enter %{attribute_with_indefinite_article} in the correct format"
+          blank: "Enter %{attribute_with_indefinite_article}"
           minimum: "%{attribute} must be after %{minimum_date}"
           attributes:
             title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,8 +17,42 @@ en:
           blank: "Enter %{attribute_with_indefinite_article}"
           minimum: "%{attribute} must be after %{minimum_date}"
           attributes:
+            contact:
+              contact_links:
+                url:
+                  blank: "Enter a URL"
+                  invalid: "Enter a URL in the correct format"
+              telephones:
+                telephone_numbers:
+                  blank: "Enter a telephone number"
+                  label:
+                    blank: "Enter a telephone label"
+            time_period:
+              date_range:
+                start:
+                  blank: "Enter a start date"
+                  invalid: "Enter a real date"
+                end:
+                  blank: "Enter an end date"
+                  invalid: "Enter a real date"
+                  minimum: "The end date must be after the start date"
+            tax:
+              things_taxed:
+                type:
+                  blank: "Select type"
+                rates:
+                  blank: "Add at least one rate"
+                  name:
+                    blank: "Enter a rate name"
+                  value:
+                    blank: "Enter a rate value"
+                  bands:
+                    name:
+                      blank: "Enter a band name"
             title:
               blank: "Enter a title"
+            change_note:
+              blank: "Enter a change note"
             lead_organisation_id:
               blank: "Select a lead organisation"
             schedule_publishing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,14 @@
 en:
+  errors:
+    format: "%{message}"
   activerecord:
     errors:
       title: There is a problem
       models:
         document:
           attributes:
+            title:
+              missing_valid_chars: "%{attribute} must include at least one letter or number"
             block_type:
               blank: Select a content block
               contact_methods:
@@ -12,7 +16,6 @@ en:
         edition:
           title:
             not_unique: "A content block with the same title already exists. If you continue, this block will not have a unique title."
-          format: "%{message}"
           invalid: "Enter %{attribute_with_indefinite_article} in the correct format"
           blank: "Enter %{attribute_with_indefinite_article}"
           minimum: "%{attribute} must be after %{minimum_date}"
@@ -49,8 +52,6 @@ en:
                   bands:
                     name:
                       blank: "Enter a band name"
-            title:
-              blank: "Enter a title"
             change_note:
               blank: "Enter a change note"
             lead_organisation_id:
@@ -102,9 +103,6 @@ en:
           invalid: "Lead Organisation is not valid"
         request:
           invalid: Invalid request
-        title:
-          missing_valid_chars: "must include at least one letter or number"
-
   domain_event:
     title:
       edition:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,10 @@ en:
           blank: "%{attribute} cannot be blank"
           minimum: "%{attribute} must be after %{minimum_date}"
           attributes:
+            title:
+              blank: "Enter a title"
+            lead_organisation_id:
+              blank: "Select a lead organisation"
             schedule_publishing:
               blank: "Select publish date"
             call_charges_info_url:
@@ -65,7 +69,7 @@ en:
         request:
           invalid: Invalid request
         title:
-          missing_valid_chars: "must contain at least one letter or number"
+          missing_valid_chars: "must include at least one letter or number"
 
   domain_event:
     title:

--- a/features/step_definitions/embedded_object_steps.rb
+++ b/features/step_definitions/embedded_object_steps.rb
@@ -129,14 +129,16 @@ Then("I should see errors for the required {string} fields") do |object_type|
   schema = @schema.subschema(object_type.pluralize)
   required_fields = schema.body["required"]
   required_fields.each do |required_field|
-    assert_text "#{Edition.human_attribute_name("details_#{required_field}")} cannot be blank", minimum: 2
+    field = schema.field(required_field)
+    assert_text field.error_message("blank"), minimum: 2
   end
 end
 
 Then("I should see errors for the required nested {string} fields") do |nested_object_name|
   subschema = @schema.subschema(@object_type.pluralize)
   required_fields(subschema, nested_object_name).each do |required_field|
-    expect(page).to have_text("#{Edition.human_attribute_name("details_#{required_field}")} cannot be blank")
+    field = subschema.field(nested_object_name.pluralize).nested_field(required_field)
+    expect(page).to have_text(field.error_message("blank"))
   end
 end
 

--- a/features/step_definitions/error_message_steps.rb
+++ b/features/step_definitions/error_message_steps.rb
@@ -11,13 +11,13 @@ Then(/^I should see an error prompting me to choose a contact method$/) do
 end
 
 Then("I should see errors for the required fields") do
-  assert_text "Title cannot be blank", minimum: 2
+  assert_text "Enter a title", minimum: 2
 
   required_fields = @schema.fields.select(&:is_required?).map(&:name)
   required_fields.each do |required_field|
     assert_text "#{Edition.human_attribute_name("details_#{required_field}")} cannot be blank", minimum: 2
   end
-  assert_text "Lead organisation cannot be blank", minimum: 2
+  assert_text "Select a lead organisation", minimum: 2
 end
 
 Then("I should see a message that the filter dates are invalid") do

--- a/spec/components/shared/error_summary_component_spec.rb
+++ b/spec/components/shared/error_summary_component_spec.rb
@@ -126,7 +126,8 @@ class ErrorSummaryTestObject
   include ActiveModel::Model
   attr_accessor :title, :date
 
-  validates :title, :date, presence: true
+  validates :title, presence: { message: "Title can't be blank" }
+  validates :date, presence: { message: "Date can't be blank" }
   validate :date_is_a_date
 
   def initialize(title, date)
@@ -135,6 +136,6 @@ class ErrorSummaryTestObject
   end
 
   def date_is_a_date
-    errors.add(:date, :invalid) unless date.is_a?(Date)
+    errors.add(:date, "Date is invalid") unless date.is_a?(Date)
   end
 end

--- a/spec/requests/workflow_spec.rb
+++ b/spec/requests/workflow_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe "Workflow", type: :request do
               }
 
           expect(response).to render_template("editions/workflow/edit_draft")
-          expect(page).to have_text(I18n.t("activerecord.errors.models.edition.attributes.title.blank"))
+          expect(page).to have_text(I18n.t("activerecord.errors.models.edition.blank", attribute_with_indefinite_article: "a title"))
         end
       end
     end

--- a/spec/requests/workflow_spec.rb
+++ b/spec/requests/workflow_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe "Workflow", type: :request do
               }
 
           expect(response).to render_template("editions/workflow/edit_draft")
-          expect(page).to have_text(I18n.t("activerecord.errors.models.edition.blank", attribute: "Title"))
+          expect(page).to have_text(I18n.t("activerecord.errors.models.edition.attributes.title.blank"))
         end
       end
     end

--- a/spec/requests/workflow_spec.rb
+++ b/spec/requests/workflow_spec.rb
@@ -509,7 +509,7 @@ RSpec.describe "Workflow", type: :request do
                 },
               }
 
-          expect(page).to have_text(I18n.t("activerecord.errors.models.edition.blank", attribute: "Change note"))
+          expect(page).to have_text(I18n.t("activerecord.errors.models.edition.attributes.change_note.blank"))
         end
 
         it "shows an error if major_change is blank" do

--- a/spec/unit/app/models/document_spec.rb
+++ b/spec/unit/app/models/document_spec.rb
@@ -198,11 +198,20 @@ RSpec.describe Document, type: :model do
       expect(document.content_id_alias).to eq("this-is-a-title")
     end
 
-    it "ensures the sluggable string must contain some letters or numbers" do
-      document = build(:document, sluggable_string: "💯💯💯")
+    {
+      pension: "Title",
+      contact: "Contact name",
+      tax: "Tax name",
+      time_period: "Time period name",
+    }.each do |block_type, attribute_name|
+      context "when the edition is a #{block_type}" do
+        it "ensures the sluggable string must contain some letters or numbers" do
+          document = build(:document, block_type, sluggable_string: "💯💯💯")
 
-      expect(document.valid?).to be(false)
-      expect(document.errors[:title]).to include(I18n.t("document.index.errors.title.missing_valid_chars"))
+          expect(document.valid?).to be(false)
+          expect(document.errors[:title]).to include(I18n.t("activerecord.errors.models.document.attributes.title.missing_valid_chars", attribute: attribute_name))
+        end
+      end
     end
   end
 

--- a/spec/unit/app/models/edition/edition_spec.rb
+++ b/spec/unit/app/models/edition/edition_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Edition, type: :model do
 
       aggregate_failures do
         expect_model_not_to_be_valid(model: edition, context: :change_note)
-        expect(edition.errors.full_messages).to include("Change note cannot be blank")
+        expect(edition.errors.full_messages).to include("Enter a change note")
       end
     end
 

--- a/spec/unit/app/models/edition/edition_spec.rb
+++ b/spec/unit/app/models/edition/edition_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Edition, type: :model do
 
     aggregate_failures do
       expect_model_not_to_be_valid(model: edition)
-      expect(edition.errors.full_messages).to include("Title cannot be blank")
+      expect(edition.errors.full_messages).to include("Enter a title")
     end
   end
 

--- a/spec/unit/app/models/edition/edition_spec.rb
+++ b/spec/unit/app/models/edition/edition_spec.rb
@@ -118,20 +118,30 @@ RSpec.describe Edition, type: :model do
     end
   end
 
-  it "validates the presence of an edition title" do
-    edition = build(
-      :edition,
-      created_at:,
-      updated_at:,
-      details:,
-      document_attributes: {},
-      lead_organisation_id: organisation.id.to_s,
-      title: nil,
-    )
+  {
+    pension: "a title",
+    contact: "a contact name",
+    tax: "a tax name",
+    time_period: "a time period name",
+  }.each do |block_type, attribute_name|
+    context "when the edition is a #{block_type}" do
+      it "validates the presence of an edition title with the correct error message" do
+        edition = build(
+          :edition,
+          block_type,
+          created_at:,
+          updated_at:,
+          details:,
+          document: build(:document, block_type: block_type),
+          lead_organisation_id: organisation.id.to_s,
+          title: nil,
+        )
 
-    aggregate_failures do
-      expect_model_not_to_be_valid(model: edition)
-      expect(edition.errors.full_messages).to include("Enter a title")
+        aggregate_failures do
+          expect_model_not_to_be_valid(model: edition)
+          expect(edition.errors.full_messages).to include("Enter #{attribute_name}")
+        end
+      end
     end
   end
 

--- a/spec/unit/app/models/schema/field/translations_spec.rb
+++ b/spec/unit/app/models/schema/field/translations_spec.rb
@@ -61,4 +61,116 @@ RSpec.describe Schema::Field::Translations do
       end
     end
   end
+
+  describe "#error_message" do
+    let(:error_type) { "blank" }
+
+    before do
+      allow(I18n).to receive(:t).and_call_original
+    end
+
+    context "when the field does not have any parent schemas" do
+      it "looks up the error message with the correct path" do
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.#{error_type}",
+          hash_including(attribute: field.label),
+        ).and_return("fallback message")
+
+        field.error_message(error_type)
+
+        expect(I18n).to have_received(:t).with(
+          "activerecord.errors.models.edition.attributes.#{schema.block_type}.#{field.name}.#{error_type}",
+          hash_including(default: "fallback message"),
+        )
+      end
+
+      it "uses the fallback message when specific message is not found" do
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.attributes.#{schema.block_type}.#{field.name}.#{error_type}",
+          any_args,
+        ).and_call_original
+
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.#{error_type}",
+          hash_including(attribute: field.label),
+        ).and_return("Something can't be blank")
+
+        result = field.error_message(error_type)
+
+        expect(result).to eq("Something can't be blank")
+      end
+
+      it "passes additional arguments to the translation" do
+        allow(I18n).to receive(:t).and_return("message with count: 5")
+
+        field.error_message(error_type, count: 5)
+
+        expect(I18n).to have_received(:t).with(
+          "activerecord.errors.models.edition.#{error_type}",
+          hash_including(attribute: field.label, count: 5),
+        )
+      end
+    end
+
+    context "when the field has a parent schema" do
+      let(:root_schema) { build(:schema, block_type: "root") }
+      let(:schema) { build(:embedded_schema, parent_schema: root_schema, block_type: "schema") }
+
+      it "looks up the error message with the correct nested path" do
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.#{error_type}",
+          hash_including(attribute: field.label),
+        ).and_return("fallback message")
+
+        field.error_message(error_type)
+
+        expect(I18n).to have_received(:t).with(
+          "activerecord.errors.models.edition.attributes.root.schema.#{field.name}.#{error_type}",
+          hash_including(default: "fallback message"),
+        )
+      end
+    end
+
+    context "when the field has multiple parent schemas" do
+      let(:root_schema) { build(:schema, block_type: "root") }
+      let(:parent_schema) { build(:embedded_schema, parent_schema: root_schema, block_type: "parent") }
+      let(:schema) { build(:embedded_schema, parent_schema:, block_type: "schema") }
+
+      it "looks up the error message with the correct deeply nested path" do
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.#{error_type}",
+          hash_including(attribute: field.label),
+        ).and_return("fallback message")
+
+        field.error_message(error_type)
+
+        expect(I18n).to have_received(:t).with(
+          "activerecord.errors.models.edition.attributes.root.parent.schema.#{field.name}.#{error_type}",
+          hash_including(default: "fallback message"),
+        )
+      end
+    end
+
+    context "when passing interpolation variables" do
+      it "passes variables to both primary and fallback translations" do
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.too_long",
+          hash_including(attribute: field.label, count: 100),
+        ).and_return("fallback message")
+
+        allow(I18n).to receive(:t).with(
+          "activerecord.errors.models.edition.attributes.#{schema.block_type}.#{field.name}.too_long",
+          hash_including(count: 100),
+        ).and_return("custom too long")
+
+        result = field.error_message("too_long", count: 100)
+
+        expect(I18n).to have_received(:t).with(
+          "activerecord.errors.models.edition.attributes.#{schema.block_type}.#{field.name}.too_long",
+          hash_including(count: 100, default: anything),
+        )
+        expect(result).to eq("custom too long")
+      end
+    end
+  end
 end

--- a/spec/unit/app/models/schema/field/translations_spec.rb
+++ b/spec/unit/app/models/schema/field/translations_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Schema::Field::Translations do
+  include ApplicationHelper
+
   let(:schema) { build(:schema) }
   let(:field) { Schema::Field.new("something", schema) }
 
@@ -73,7 +75,10 @@ RSpec.describe Schema::Field::Translations do
       it "looks up the error message with the correct path" do
         allow(I18n).to receive(:t).with(
           "activerecord.errors.models.edition.#{error_type}",
-          hash_including(attribute: field.label),
+          hash_including(
+            attribute: field.label.downcase,
+            attribute_with_indefinite_article: add_indefinite_article(field.label.downcase),
+          ),
         ).and_return("fallback message")
 
         field.error_message(error_type)
@@ -93,11 +98,11 @@ RSpec.describe Schema::Field::Translations do
         allow(I18n).to receive(:t).with(
           "activerecord.errors.models.edition.#{error_type}",
           hash_including(attribute: field.label),
-        ).and_return("Something can't be blank")
+        ).and_return("Enter a something")
 
         result = field.error_message(error_type)
 
-        expect(result).to eq("Something can't be blank")
+        expect(result).to eq("Enter a something")
       end
 
       it "passes additional arguments to the translation" do
@@ -119,7 +124,10 @@ RSpec.describe Schema::Field::Translations do
       it "looks up the error message with the correct nested path" do
         allow(I18n).to receive(:t).with(
           "activerecord.errors.models.edition.#{error_type}",
-          hash_including(attribute: field.label),
+          hash_including(
+            attribute: field.label.downcase,
+            attribute_with_indefinite_article: add_indefinite_article(field.label.downcase),
+          ),
         ).and_return("fallback message")
 
         field.error_message(error_type)
@@ -139,7 +147,10 @@ RSpec.describe Schema::Field::Translations do
       it "looks up the error message with the correct deeply nested path" do
         allow(I18n).to receive(:t).with(
           "activerecord.errors.models.edition.#{error_type}",
-          hash_including(attribute: field.label),
+          hash_including(
+            attribute: field.label.downcase,
+            attribute_with_indefinite_article: add_indefinite_article(field.label.downcase),
+          ),
         ).and_return("fallback message")
 
         field.error_message(error_type)
@@ -155,7 +166,11 @@ RSpec.describe Schema::Field::Translations do
       it "passes variables to both primary and fallback translations" do
         allow(I18n).to receive(:t).with(
           "activerecord.errors.models.edition.too_long",
-          hash_including(attribute: field.label, count: 100),
+          hash_including(
+            attribute: field.label.downcase,
+            attribute_with_indefinite_article: add_indefinite_article(field.label.downcase),
+            count: 100,
+          ),
         ).and_return("fallback message")
 
         allow(I18n).to receive(:t).with(

--- a/spec/unit/app/models/schema/field_spec.rb
+++ b/spec/unit/app/models/schema/field_spec.rb
@@ -248,6 +248,113 @@ RSpec.describe Schema::Field do
     end
   end
 
+  describe "#all_nested_fields" do
+    context "when field has no nested fields" do
+      let(:body) do
+        {
+          "properties" => {
+            "something" => {
+              "type" => "string",
+            },
+          },
+        }
+      end
+
+      it "returns an empty array" do
+        expect(field.all_nested_fields).to eq([])
+      end
+    end
+
+    context "when field has nested fields but no deeper nesting" do
+      let(:body) do
+        {
+          "properties" => {
+            "something" => {
+              "type" => "object",
+              "properties" => {
+                "foo" => { "type" => "string" },
+                "bar" => { "type" => "string" },
+              },
+            },
+          },
+        }
+      end
+
+      it "returns the direct nested fields" do
+        all_nested = field.all_nested_fields
+        expect(all_nested.map(&:name)).to eq(%w[foo bar])
+        expect(all_nested.count).to eq(2)
+      end
+    end
+
+    context "when field has deeply nested fields" do
+      let(:body) do
+        {
+          "properties" => {
+            "something" => {
+              "type" => "object",
+              "properties" => {
+                "level1" => { "type" => "string" },
+                "nested_obj" => {
+                  "type" => "object",
+                  "properties" => {
+                    "level2" => { "type" => "string" },
+                    "level2b" => { "type" => "string" },
+                  },
+                },
+              },
+            },
+          },
+        }
+      end
+
+      it "returns all nested fields including deeply nested ones" do
+        all_nested = field.all_nested_fields
+        field_names = all_nested.map(&:name)
+
+        expect(field_names).to include("level1")
+        expect(field_names).to include("nested_obj")
+        expect(field_names).to include("level2")
+        expect(field_names).to include("level2b")
+        expect(all_nested.count).to eq(4)
+      end
+    end
+
+    context "when field has nested arrays with objects" do
+      let(:body) do
+        {
+          "properties" => {
+            "something" => {
+              "type" => "object",
+              "properties" => {
+                "items" => {
+                  "type" => "array",
+                  "items" => {
+                    "type" => "object",
+                    "properties" => {
+                      "name" => { "type" => "string" },
+                      "value" => { "type" => "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      end
+
+      it "includes fields from nested arrays" do
+        all_nested = field.all_nested_fields
+        field_names = all_nested.map(&:name)
+
+        expect(field_names).to include("items")
+        expect(field_names).to include("name")
+        expect(field_names).to include("value")
+        expect(all_nested.count).to eq(3)
+      end
+    end
+  end
+
   describe "#array_items" do
     describe "when there are no properties present" do
       it "returns nil" do

--- a/spec/unit/app/models/schema_spec.rb
+++ b/spec/unit/app/models/schema_spec.rb
@@ -353,6 +353,175 @@ RSpec.describe Schema do
     end
   end
 
+  describe "#all_fields" do
+    context "when schema has only simple fields" do
+      let(:body) do
+        {
+          "properties" => {
+            "title" => { "type" => "string" },
+            "description" => { "type" => "string" },
+          },
+        }
+      end
+
+      it "returns all fields" do
+        all_fields = schema.all_fields
+        expect(all_fields.map(&:name)).to eq(%w[title description])
+      end
+    end
+
+    context "when schema has subschemas (embedded objects)" do
+      let(:body) do
+        {
+          "properties" => {
+            "title" => { "type" => "string" },
+            "contact_info" => {
+              "type" => "object",
+              "properties" => {
+                "email" => { "type" => "string" },
+                "phone" => { "type" => "string" },
+              },
+            },
+          },
+        }
+      end
+
+      it "includes fields from subschemas" do
+        all_fields = schema.all_fields
+        field_names = all_fields.map(&:name)
+
+        expect(field_names).to include("title")
+        expect(field_names).to include("email")
+        expect(field_names).to include("phone")
+      end
+
+      it "returns the correct number of fields" do
+        all_fields = schema.all_fields
+        expect(all_fields.length).to eq(3)
+      end
+    end
+
+    context "when schema has nested fields within fields" do
+      let(:body) do
+        {
+          "properties" => {
+            "title" => { "type" => "string" },
+            "metadata" => {
+              "type" => "object",
+              "properties" => {
+                "author" => { "type" => "string" },
+                "tags" => {
+                  "type" => "array",
+                  "items" => {
+                    "type" => "object",
+                    "properties" => {
+                      "name" => { "type" => "string" },
+                      "value" => { "type" => "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      end
+
+      it "includes all nested fields recursively" do
+        all_fields = schema.all_fields
+        field_names = all_fields.map(&:name)
+
+        expect(field_names).to include("title")
+        expect(field_names).to include("author")
+        expect(field_names).to include("tags")
+        expect(field_names).to include("name")
+        expect(field_names).to include("value")
+      end
+    end
+
+    context "when schema has multiple subschemas" do
+      let(:body) do
+        {
+          "properties" => {
+            "title" => { "type" => "string" },
+            "contact" => {
+              "type" => "object",
+              "properties" => {
+                "email" => { "type" => "string" },
+              },
+            },
+            "address" => {
+              "type" => "object",
+              "properties" => {
+                "street" => { "type" => "string" },
+                "city" => { "type" => "string" },
+              },
+            },
+          },
+        }
+      end
+
+      it "includes fields from all subschemas" do
+        all_fields = schema.all_fields
+        field_names = all_fields.map(&:name)
+
+        expect(field_names).to include("title")
+        expect(field_names).to include("email")
+        expect(field_names).to include("street")
+        expect(field_names).to include("city")
+        expect(all_fields.length).to eq(4)
+      end
+    end
+
+    context "when schema has complex nested structure" do
+      let(:body) do
+        {
+          "properties" => {
+            "name" => { "type" => "string" },
+            "company" => {
+              "type" => "object",
+              "properties" => {
+                "company_name" => { "type" => "string" },
+                "employees" => {
+                  "type" => "array",
+                  "items" => {
+                    "type" => "object",
+                    "properties" => {
+                      "employee_name" => { "type" => "string" },
+                      "role" => { "type" => "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "location" => {
+              "type" => "object",
+              "properties" => {
+                "country" => { "type" => "string" },
+              },
+            },
+          },
+        }
+      end
+
+      it "returns all fields from nested structure" do
+        all_fields = schema.all_fields
+        field_names = all_fields.map(&:name)
+
+        expect(field_names).to include("name")
+        expect(field_names).to include("company_name")
+        expect(field_names).to include("employees")
+        expect(field_names).to include("employee_name")
+        expect(field_names).to include("role")
+        expect(field_names).to include("country")
+      end
+
+      it "returns Field instances" do
+        all_fields = schema.all_fields
+        expect(all_fields).to all(be_a(Schema::Field))
+      end
+    end
+  end
+
   describe "#live?" do
     let(:schema) { build(:schema, block_type:) }
     subject { schema.live? }

--- a/spec/unit/app/validators/details_validator/contact_spec.rb
+++ b/spec/unit/app/validators/details_validator/contact_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the email_address field" do
-          expect(errors[:details_email_addresses_email_address]).to include("Email address cannot be blank")
+          expect(errors[:details_email_addresses_email_address]).to include("Enter an email address")
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the email_address field" do
-          expect(errors[:details_email_addresses_email_address]).to include("Invalid Email address")
+          expect(errors[:details_email_addresses_email_address]).to include("Enter an email address in the correct format")
         end
       end
 
@@ -121,7 +121,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the label field" do
-          expect(errors[:details_contact_links_label]).to include("Label cannot be blank")
+          expect(errors[:details_contact_links_label]).to include("Enter a label")
         end
       end
 
@@ -137,7 +137,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the url field" do
-          expect(errors[:details_contact_links_url]).to include("URL cannot be blank")
+          expect(errors[:details_contact_links_url]).to include("Enter a URL")
         end
       end
 
@@ -147,7 +147,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the url field" do
-          expect(errors[:details_contact_links_url]).to include("URL is invalid")
+          expect(errors[:details_contact_links_url]).to include("Enter a URL in the correct format")
         end
       end
     end
@@ -165,7 +165,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the telephone_numbers field" do
-          expect(errors[:details_telephones_telephone_numbers]).to include("Telephone numbers cannot be blank")
+          expect(errors[:details_telephones_telephone_numbers]).to include("Enter a telephone number")
         end
       end
 
@@ -177,7 +177,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the label field" do
-          expect(errors[:details_telephones_telephone_numbers_0_label]).to include("Label cannot be blank")
+          expect(errors[:details_telephones_telephone_numbers_0_label]).to include("Enter a telephone label")
         end
       end
 
@@ -189,7 +189,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the telephone_number field" do
-          expect(errors[:details_telephones_telephone_numbers_0_telephone_number]).to include("Telephone number cannot be blank")
+          expect(errors[:details_telephones_telephone_numbers_0_telephone_number]).to include("Enter a telephone number")
         end
       end
 

--- a/spec/unit/app/validators/details_validator/custom_validators_spec.rb
+++ b/spec/unit/app/validators/details_validator/custom_validators_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe DetailsValidator::CustomValidators do
       expect(edition).to have_error_for(:details_date_range_end)
                            .with_error_message_for(
                              type: "minimum",
-                             attribute: "End",
+                             attribute: "end",
                              minimum_date: "date range start",
                            )
     end

--- a/spec/unit/app/validators/details_validator/pension_spec.rb
+++ b/spec/unit/app/validators/details_validator/pension_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.to_not be_valid }
 
       it "adds an error to the amount field" do
-        expect(errors[:details_rates_amount]).to include("Invalid Amount")
+        expect(errors[:details_rates_amount]).to include("Enter an amount in the correct format")
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.to_not be_valid }
 
       it "adds an error to the amount field" do
-        expect(errors[:details_rates_amount]).to include("Amount cannot be blank")
+        expect(errors[:details_rates_amount]).to include("Enter an amount")
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.to_not be_valid }
 
       it "adds an error to the amount field" do
-        expect(errors[:details_rates_frequency]).to include("Frequency cannot be blank")
+        expect(errors[:details_rates_frequency]).to include("Enter a frequency")
       end
     end
   end

--- a/spec/unit/app/validators/details_validator/tax_spec.rb
+++ b/spec/unit/app/validators/details_validator/tax_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.not_to be_valid }
 
       it "adds an error to the tax_type field" do
-        expect(errors[:details_tax_type]).to include("Tax type cannot be blank")
+        expect(errors[:details_tax_type]).to include("Enter a tax type")
       end
     end
 
@@ -91,8 +91,8 @@ RSpec.describe DetailsValidator do
 
         it { is_expected.not_to be_valid }
 
-        it "adds an error to the titke field" do
-          expect(errors[:details_things_taxed_title]).to include("Title cannot be blank")
+        it "adds an error to the title field" do
+          expect(errors[:details_things_taxed_title]).to include("Enter a title")
         end
       end
 
@@ -102,7 +102,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the type field" do
-          expect(errors[:details_things_taxed_type]).to include("Type cannot be blank")
+          expect(errors[:details_things_taxed_type]).to include("Select type")
         end
       end
 
@@ -112,7 +112,7 @@ RSpec.describe DetailsValidator do
         it { is_expected.not_to be_valid }
 
         it "adds an error to the rates field" do
-          expect(errors[:details_things_taxed_rates]).to include("Rates cannot be blank")
+          expect(errors[:details_things_taxed_rates]).to include("Add at least one rate")
         end
       end
 
@@ -123,7 +123,7 @@ RSpec.describe DetailsValidator do
           it { is_expected.not_to be_valid }
 
           it "adds an error to the name field" do
-            expect(errors[:details_things_taxed_rates_0_name]).to include("Name cannot be blank")
+            expect(errors[:details_things_taxed_rates_0_name]).to include("Enter a rate name")
           end
         end
 
@@ -133,7 +133,7 @@ RSpec.describe DetailsValidator do
           it { is_expected.not_to be_valid }
 
           it "adds an error to the name field" do
-            expect(errors[:details_things_taxed_rates_0_name]).to include("Name cannot be blank")
+            expect(errors[:details_things_taxed_rates_0_name]).to include("Enter a rate name")
           end
         end
       end
@@ -145,7 +145,7 @@ RSpec.describe DetailsValidator do
           it { is_expected.not_to be_valid }
 
           it "adds an error to the name field" do
-            expect(errors[:details_things_taxed_rates_0_bands_0_name]).to include("Name cannot be blank")
+            expect(errors[:details_things_taxed_rates_0_bands_0_name]).to include("Enter a band name")
           end
         end
       end

--- a/spec/unit/app/validators/details_validator/time_period_spec.rb
+++ b/spec/unit/app/validators/details_validator/time_period_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.not_to be_valid }
 
       it "adds an error to the start field" do
-        expect(errors[:details_date_range_start]).to include("Start is invalid")
+        expect(errors[:details_date_range_start]).to include("Enter a real date")
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.not_to be_valid }
 
       it "adds an error to the end field" do
-        expect(errors[:details_date_range_end]).to include("End is invalid")
+        expect(errors[:details_date_range_end]).to include("Enter a real date")
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.not_to be_valid }
 
       it "adds an error to the end field" do
-        expect(errors[:details_date_range_end]).to include("End must be after date range start")
+        expect(errors[:details_date_range_end]).to include("The end date must be after the start date")
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe DetailsValidator do
       it { is_expected.not_to be_valid }
 
       it "adds an error to the end field" do
-        expect(errors[:details_date_range_end]).to include("End must be after date range start")
+        expect(errors[:details_date_range_end]).to include("The end date must be after the start date")
       end
     end
   end

--- a/spec/unit/app/validators/details_validator_spec.rb
+++ b/spec/unit/app/validators/details_validator_spec.rb
@@ -248,23 +248,6 @@ RSpec.describe DetailsValidator do
     end
   end
 
-  describe "#translate_error" do
-    let(:validator) { DetailsValidator.new }
-
-    it "attempts to find a translation for a field when validation fails" do
-      attribute = "foo"
-      type = "bar"
-
-      expect(I18n).to receive(:t).with(
-        "activerecord.errors.models.edition.attributes.#{attribute}.#{type}",
-        attribute: attribute.humanize,
-        default: ["activerecord.errors.models.edition.#{type}".to_sym],
-      ).and_return("translated")
-
-      expect(validator.translate_error(type, attribute)).to eq("translated")
-    end
-  end
-
   describe "#key_with_optional_prefix" do
     let(:validator) { DetailsValidator.new }
 

--- a/spec/unit/app/validators/details_validator_spec.rb
+++ b/spec/unit/app/validators/details_validator_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe DetailsValidator do
     expect(edition).to be_invalid
 
     expect(edition).to have_error_for(:details_foo)
-                         .with_error_message_for(type: "blank", attribute: "Foo")
+                         .with_error_message_for(type: "blank", attribute: "foo", attribute_with_indefinite_article: "a foo")
     expect(edition).to have_error_for(:details_bar)
-                         .with_error_message_for(type: "blank", attribute: "Bar")
+                         .with_error_message_for(type: "blank", attribute: "bar", attribute_with_indefinite_article: "a bar")
   end
 
   it "validates the format of fields" do
@@ -72,9 +72,9 @@ RSpec.describe DetailsValidator do
     expect(edition).to be_invalid
 
     expect(edition).to have_error_for(:details_foo)
-                         .with_error_message_for(type: "invalid", attribute: "Foo")
+                         .with_error_message_for(type: "invalid", attribute: "foo", attribute_with_indefinite_article: "a foo")
     expect(edition).to have_error_for(:details_bar)
-                         .with_error_message_for(type: "invalid", attribute: "Bar")
+                         .with_error_message_for(type: "invalid", attribute: "bar", attribute_with_indefinite_article: "a bar")
   end
 
   it "validates the presence of nested fields in nested objects" do
@@ -96,7 +96,7 @@ RSpec.describe DetailsValidator do
     expect(edition).to be_invalid
 
     expect(edition).to have_error_for(:details_things_my_string)
-                         .with_error_message_for(type: "blank", attribute: "My string")
+                         .with_error_message_for(type: "blank", attribute: "my string", attribute_with_indefinite_article: "a my string")
   end
 
   it "validates the format of nested fields in nested objects" do
@@ -118,7 +118,7 @@ RSpec.describe DetailsValidator do
     expect(edition).to be_invalid
 
     expect(edition).to have_error_for(:details_things_something_else)
-                         .with_error_message_for(type: "invalid", attribute: "Something else")
+                         .with_error_message_for(type: "invalid", attribute: "something else", attribute_with_indefinite_article: "a something else")
   end
 
   describe "validating against a regular expression" do
@@ -147,7 +147,7 @@ RSpec.describe DetailsValidator do
 
       expect(edition).to be_invalid
       expect(edition).to have_error_for(:details_foo)
-                           .with_error_message_for(type: "invalid", attribute: "Foo")
+                           .with_error_message_for(type: "invalid", attribute: "foo", attribute_with_indefinite_article: "a foo")
     end
   end
 
@@ -215,7 +215,7 @@ RSpec.describe DetailsValidator do
       expect(edition).to be_invalid
 
       expect(edition).to have_error_for(:details_things_array_of_objects_1_foo)
-                           .with_error_message_for(type: "blank", attribute: "Foo")
+                           .with_error_message_for(type: "blank", attribute: "foo", attribute_with_indefinite_article: "a foo")
     end
 
     it "returns an error if an item is invalid in an array of objects" do
@@ -244,7 +244,7 @@ RSpec.describe DetailsValidator do
 
       expect(edition).to be_invalid
       expect(edition).to have_error_for(:details_things_array_of_objects_0_foo)
-                           .with_error_message_for(type: "invalid", attribute: "Foo")
+                           .with_error_message_for(type: "invalid", attribute: "foo", attribute_with_indefinite_article: "a foo")
     end
   end
 

--- a/spec/unit/app/validators/organisation_validator_spec.rb
+++ b/spec/unit/app/validators/organisation_validator_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe OrganisationValidator do
     edition = build(:edition, lead_organisation_id: nil, document:)
 
     expect(edition).to be_invalid
-    expect(edition.errors.full_messages).to eq([I18n.t("activerecord.errors.models.edition.blank", attribute: "Lead organisation")])
+    expect(edition.errors.full_messages).to eq([I18n.t("activerecord.errors.models.edition.attributes.lead_organisation_id.blank")])
   end
 end


### PR DESCRIPTION
This addresses most of the error message suggestions made in the content design review. As most of the errors on required fields are in the format `Enter a $thing`, I've made some tweaks to make translation lookups more predictable, as well as adding the ability to add the correct indefinite article (a/an) to the field name.

I haven't had chance to check if this addresses all of the suggestions in the document, and may not have chance as today's my last day, so gonna leave this in draft for now.