### PR TITLE
CM-944: store pension rate amount as numeric string

### DIFF
--- a/app/components/edition/details/fields/context.rb
+++ b/app/components/edition/details/fields/context.rb
@@ -16,6 +16,8 @@ class Edition::Details::Fields::Context
 
   attr_reader :edition, :field, :schema, :populate_with_defaults, :subschema, :object_title, :index, :details, :parent_indexes
 
+  delegate :input_prefix, to: :field
+
   def value
     value_for_field(details:, field:, populate_with_defaults:)
   end

--- a/app/components/edition/details/fields/string_component.html.erb
+++ b/app/components/edition/details/fields/string_component.html.erb
@@ -6,5 +6,6 @@
   id:,
   value:,
   error_items:,
+  prefix: input_prefix,
   hint: hint_text,
 } %>

--- a/app/components/edition/details/fields/string_component.rb
+++ b/app/components/edition/details/fields/string_component.rb
@@ -7,5 +7,5 @@ private
 
   attr_reader :context
 
-  delegate :label, :name, :id, :value, :error_items, :hint_text, to: :context
+  delegate :label, :name, :id, :value, :error_items, :hint_text, :input_prefix, to: :context
 end

--- a/app/components/edition/show/embedded_objects/blocks_component.rb
+++ b/app/components/edition/show/embedded_objects/blocks_component.rb
@@ -45,7 +45,7 @@ private
 
       {
         "#{key_name}": label,
-        value: content_for_row(suffix, item),
+        value: content_for_row(suffix, [field.input_prefix, item].compact.join),
         data: data_attributes_for_row(suffix),
       }
     end

--- a/app/components/shared/embedded_objects/summary_card_component.rb
+++ b/app/components/shared/embedded_objects/summary_card_component.rb
@@ -45,7 +45,7 @@ private
 
       {
         key: label,
-        value: translated_value(field.name, item),
+        value: [field.input_prefix, translated_value(field.name, item)].compact.join,
         data: { testid: testid_for(suffix) },
       }
     end

--- a/app/models/concerns/schema/field/configuration.rb
+++ b/app/models/concerns/schema/field/configuration.rb
@@ -8,6 +8,7 @@ class Schema::Field
     SHOW_FIELD_NAME_PROPERTY_KEY = "x-show-field-name".freeze
     COMPONENT_NAME_PROPERTY_KEY = "x-component-name".freeze
     FIELD_ORDERING_RULE_PROPERTY_KEY = "x-field-order".freeze
+    INPUT_PREFIX_PROPERTY_KEY = "x-input-prefix".freeze
 
     def hidden?
       @hidden ||= properties[HIDDEN_FIELD_PROPERTY_KEY] == true
@@ -37,6 +38,10 @@ class Schema::Field
 
     def field_ordering_rule
       @field_ordering_rule ||= properties.dig("items", FIELD_ORDERING_RULE_PROPERTY_KEY) || []
+    end
+
+    def input_prefix
+      @input_prefix ||= properties[INPUT_PREFIX_PROPERTY_KEY]
     end
 
   private

--- a/app/models/schema/definitions/pension.json
+++ b/app/models/schema/definitions/pension.json
@@ -21,13 +21,13 @@
           "properties": {
             "amount": {
               "type": "string",
-              "pattern": "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
+              "pattern": "^[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
             },
-             "description": {
-               "type": "string",
-               "x-component-name": "textarea",
-               "x-govspeak-enabled": true
-             },
+            "description": {
+              "type": "string",
+              "x-component-name": "textarea",
+              "x-govspeak-enabled": true
+            },
             "frequency": {
               "type": "string",
               "enum": ["a day", "a week", "a month", "a year"]

--- a/app/models/schema/definitions/pension.json
+++ b/app/models/schema/definitions/pension.json
@@ -21,7 +21,8 @@
           "properties": {
             "amount": {
               "type": "string",
-              "pattern": "^[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
+              "pattern": "^[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?",
+              "x-input-prefix": "£"
             },
             "description": {
               "type": "string",

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -53,19 +53,19 @@ Using the pension schema as an example, the `rates` payload looks like this:
   "rates": {
     "rate-1": {
       "title": "Rate 1",
-      "amount": "£221.20",
+      "amount": "221.20",
       "frequency": "a week",
       "description": "Your weekly pension amount"
     },
     "rate-2": {
       "title": "Rate without decimal point",
-      "amount": "£221",
+      "amount": "221",
       "frequency": "a week",
       "description": "Your weekly pension amount"
     },
     "rate-3": {
       "title": "Rate with big value",
-      "amount": "£1,223",
+      "amount": "1,223",
       "frequency": "a week",
       "description": "Your weekly pension amount"
     }

--- a/engines/block_preview/spec/components/block_preview/preview_details_spec.rb
+++ b/engines/block_preview/spec/components/block_preview/preview_details_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe BlockPreview::PreviewDetailsComponent, type: :component do
         "description": "Basic state pension",
         "rates": {
           "rate1":
-            { "title": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
+            { "title": "rate1", "amount": "100.5", "frequency": "a week", "description": "" },
           "rate2":
-            { "title": "rate2", "amount": "£11.1", "frequency": "a month", "description": "1111" },
+            { "title": "rate2", "amount": "11.1", "frequency": "a month", "description": "1111" },
         },
       })
     end

--- a/engines/fact_check/app/components/fact_check/embedded_block_diff_component.rb
+++ b/engines/fact_check/app/components/fact_check/embedded_block_diff_component.rb
@@ -19,18 +19,19 @@ private
 
   def rows
     first_class_items(items).flat_map do |key, value|
+      field = schema.field(key)
       {
-        key: schema.field(key).label,
-        value: content_for_row(value),
+        key: field.label,
+        value: content_for_row(value, field),
       }
     end
   end
 
-  def content_for_row(value)
+  def content_for_row(value, field)
     if value["published"]
-      content_tag(:div, render_diff(value["published"], value["new"]), class: "compare-editions")
+      content_tag(:div, render_diff([field.input_prefix, value["published"]].compact.join, [field.input_prefix, value["new"]].compact.join), class: "compare-editions")
     else
-      value["new"]
+      [field.input_prefix, value["new"]].compact.join
     end
   end
 

--- a/engines/fact_check/features/fact_check.feature
+++ b/engines/fact_check/features/fact_check.feature
@@ -42,11 +42,11 @@ Feature: Fact check preview
     Given a pension content block has been created
     And that pension has a rate with the following fields:
       | title      | amount | frequency |
-      | my pension | £123   | a day |
+      | my pension | 123    | a day |
     And a pension content block has been drafted
     And that pension has a rate with the following fields:
-      | title          | amount | frequency |
-      | my pension  | £444   | a month   |
+      | title       | amount | frequency |
+      | my pension  | 444    | a month   |
     When I visit the fact check path for the block
     Then I should see the block's title
     And I should see "£123" as a previous value

--- a/engines/fact_check/spec/components/embedded_block_diff_component_spec.rb
+++ b/engines/fact_check/spec/components/embedded_block_diff_component_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe FactCheck::EmbeddedBlockDiffComponent, type: :component do
   let(:object_type) { "example_type" }
   let(:object_title) { "Example Title" }
 
-  let(:subschema_body) { { "properties" => { "amount" => "" } } }
+  let(:subschema_body) do
+    { "properties" => { "amount" => { "type" => "string", "x-input-prefix" => "£" } } }
+  end
   let(:subschema) { build(:embedded_schema, body: subschema_body) }
 
   let(:schema) { double(:schema) }
@@ -29,7 +31,7 @@ RSpec.describe FactCheck::EmbeddedBlockDiffComponent, type: :component do
   end
 
   describe "when there is data to render" do
-    let(:items_new) { { "amount" => "£12.34" } }
+    let(:items_new) { { "amount" => "12.34" } }
 
     before do
       allow(schema).to receive(:subschema).with(object_type).and_return(subschema)
@@ -49,8 +51,8 @@ RSpec.describe FactCheck::EmbeddedBlockDiffComponent, type: :component do
     end
 
     describe "when the block has a published edition and a newer unpublished edition" do
-      let(:items_new) { { "amount" => "£12.34" } }
-      let(:items_published) { { "amount" => "£1.234" } }
+      let(:items_new) { { "amount" => "12.34" } }
+      let(:items_published) { { "amount" => "1.234" } }
 
       it "should render the diff between the two editions" do
         expect(page).to have_summary_row.with_key("Amount").with_css(".compare-editions .diff del", text: "£1.234")
@@ -59,7 +61,7 @@ RSpec.describe FactCheck::EmbeddedBlockDiffComponent, type: :component do
     end
 
     describe "when the block does not have a published edition" do
-      let(:items_new) { { "amount" => "£12.34" } }
+      let(:items_new) { { "amount" => "12.34" } }
       let(:items_published) { {} }
 
       it "should render only the new edition with no diff" do

--- a/engines/fact_check/spec/components/ungrouped_subschema_diff_component_spec.rb
+++ b/engines/fact_check/spec/components/ungrouped_subschema_diff_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FactCheck::UngroupedSubschemaDiffComponent, type: :component do
                            {
                              "title" => "",
                              "frequency" => "",
-                             "amount" => "",
+                             "amount" => { "type" => "string", "x-input-prefix" => "£" },
                            } })
   end
   let(:schema) { build(:schema) }
@@ -18,7 +18,7 @@ RSpec.describe FactCheck::UngroupedSubschemaDiffComponent, type: :component do
               "my_rate" => {
                 "title" => "my title",
                 "frequency" => "weekly",
-                "amount" => "£1000",
+                "amount" => "1000",
               },
               "my_rate_2" => {
                 "title" => "my title 2",

--- a/features/pension/create_block.feature
+++ b/features/pension/create_block.feature
@@ -41,7 +41,7 @@ Feature: Create a pension block
     And there should be no accessibility errors
     And I complete the "rate" form with the following fields:
       | title    | amount  | frequency |
-      | New rate | £127.91 | a month  |
+      | New rate | 127.91  | a month  |
     Then I should be on the "add_embedded_rates" step
     When I save and continue
     Then there should be no accessibility errors

--- a/features/step_definitions/pension_block_steps.rb
+++ b/features/step_definitions/pension_block_steps.rb
@@ -6,7 +6,7 @@ Given("the pension has a rate set") do
   pension.details[:rates] = {
     "my-rate" => {
       "title" => "My Rate",
-      "amount" => "£123.45",
+      "amount" => "123.45",
       "frequency" => "a month",
     },
   }

--- a/features/view_object.feature
+++ b/features/view_object.feature
@@ -5,7 +5,7 @@ Feature: View a content object
     And a pension content block has been created
     And that pension has a rate with the following fields:
       | title   | amount  | frequency |
-      | My rate | £123.45 | a week    |
+      | My rate | 123.45  | a week    |
     And a published contact edition exists
 
   Scenario: GDS Editor views a content object

--- a/lib/tasks/remove_pound_symbol_prefix_from_pension_amount_value.rake
+++ b/lib/tasks/remove_pound_symbol_prefix_from_pension_amount_value.rake
@@ -1,0 +1,44 @@
+namespace :data_migration do
+  desc "Remove pound symbol prefix from Pension#amount values"
+  task remove_pound_symbol_prefix_from_pension_amount_value: :environment do
+    log = proc { |str|
+      timestamp = Time.current.strftime("%F %T")
+      line = "#{timestamp} > #{str}"
+      puts line unless Rails.env.test?
+      Rails.logger.info(line)
+    }
+
+    log.call("Removing pound symbol prefix from Pension#amount values")
+    editions = Edition.joins(:document).where(document: { block_type: "pension" })
+
+    log.call("#{editions.count} editions of type Pension found")
+
+    editions.each do |edition|
+      rates = edition.details["rates"]
+      updated_any_rate = false
+
+      next unless rates
+
+      rates.each do |_, rate|
+        amount = rate["amount"]
+
+        next unless amount&.start_with?("£")
+
+        log.call("Converting edition #{edition.id}: #{edition.title} (#{rate['amount']} #{rate['frequency']})")
+
+        rate["amount"] = amount.delete_prefix("£")
+        updated_any_rate = true
+      end
+
+      next unless updated_any_rate
+
+      edition.details["rates"] = rates
+      edition.save!(validate: false)
+      log.call(" -> Edition #{edition.id} successfully updated.")
+
+      edition.details["rates"].each do |_, rate|
+        log.call("Edition #{edition.id} final rate value: #{rate['amount']} #{rate['frequency']}")
+      end
+    end
+  end
+end

--- a/spec/components/edition/details/fields/string_component_spec.rb
+++ b/spec/components/edition/details/fields/string_component_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe Edition::Details::Fields::StringComponent, type: :component do
   let(:component) { described_class.new(context) }
 
   it_behaves_like "a field component", field_type: "input"
+
+  context "when an input prefix is defined" do
+    before do
+      expect(context).to receive(:input_prefix).and_return("£")
+    end
+
+    it "should render the input prefix" do
+      render_inline component
+
+      expect(page).to have_content "£"
+    end
+  end
 end

--- a/spec/components/edition/show/embedded_objects/blocks_component_spec.rb
+++ b/spec/components/edition/show/embedded_objects/blocks_component_spec.rb
@@ -80,6 +80,31 @@ RSpec.describe Edition::Show::EmbeddedObjects::BlocksComponent, type: :component
       expect(page).to_not have_css ".app-c-embedded-objects-blocks-component__details-wrapper"
     end
 
+    describe "when a field has an input_prefix" do
+      let(:foo_field) { build(:field, label: "Foo", input_prefix: "£") }
+
+      it "prepends the prefix to the value" do
+        render_inline component
+        expect_summary_list_row(test_id: "else_foo", key: "Foo", value: "£bar", embed_code_suffix: "foo")
+      end
+    end
+
+    describe "when a field has no input prefix" do
+      let(:foo_field) { build(:field, label: "Foo", input_prefix: nil) }
+      it "renders the value without any prefix" do
+        render_inline component
+        expect_summary_list_row(test_id: "else_foo", key: "Foo", value: "bar", embed_code_suffix: "foo")
+      end
+    end
+
+    describe "when a field has an empty string as input prefix" do
+      let(:foo_field) { build(:field, label: "Foo", input_prefix: "") }
+      it "renders the value without any prefix" do
+        render_inline component
+        expect_summary_list_row(test_id: "else_foo", key: "Foo", value: "bar", embed_code_suffix: "foo")
+      end
+    end
+
     describe "when items contain an array" do
       let(:items) do
         {

--- a/spec/components/shared/embedded_objects/summary_card_component_spec.rb
+++ b/spec/components/shared/embedded_objects/summary_card_component_spec.rb
@@ -168,6 +168,80 @@ RSpec.describe Shared::EmbeddedObjects::SummaryCardComponent, type: :component d
     expect(page).to have_css ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
   end
 
+  describe "input prefix (e.g. for currency symbol)" do
+    context "when the field has an input prefix" do
+      it "renders a value with a prefix" do
+        fields = [build(:field, name: "amount", label: "Amount", input_prefix: "£")]
+        allow(subschema).to receive(:fields).and_return(fields)
+
+        details = {
+          "embedded-objects" => {
+            "my-embedded-object" => { "amount" => "100.00" },
+          },
+        }
+        edition = build_stubbed(:edition, :pension, details:, document:)
+
+        component = described_class.new(
+          edition:,
+          object_type: "embedded-objects",
+          object_title: "my-embedded-object",
+        )
+
+        render_inline component
+
+        expect(page).to have_css ".govuk-summary-list__value", text: "£100.00"
+      end
+    end
+
+    context "when the field has an empty input prefix" do
+      it "renders a value with no prefix" do
+        fields = [build(:field, name: "something", label: "Something", input_prefix: "")]
+        allow(subschema).to receive(:fields).and_return(fields)
+
+        details = {
+          "embedded-objects" => {
+            "my-embedded-object" => { "something" => "100.00" },
+          },
+        }
+        edition = build_stubbed(:edition, :pension, details:, document:)
+
+        component = described_class.new(
+          edition:,
+          object_type: "embedded-objects",
+          object_title: "my-embedded-object",
+        )
+
+        render_inline component
+
+        expect(page).to have_css ".govuk-summary-list__value", text: "100.00"
+      end
+    end
+
+    context "when the field has no input prefix" do
+      it "renders a value with no prefix" do
+        fields = [build(:field, name: "something", label: "Something")]
+        allow(subschema).to receive(:fields).and_return(fields)
+
+        details = {
+          "embedded-objects" => {
+            "my-embedded-object" => { "something" => "100.00" },
+          },
+        }
+        edition = build_stubbed(:edition, :pension, details:, document:)
+
+        component = described_class.new(
+          edition:,
+          object_type: "embedded-objects",
+          object_title: "my-embedded-object",
+        )
+
+        render_inline component
+
+        expect(page).to have_css ".govuk-summary-list__value", text: "100.00"
+      end
+    end
+  end
+
   describe "when arrays are present" do
     let(:name_field) { build(:field, name: "name", label: "Name") }
     let(:field_field) { build(:field, name: "field", label: "Field") }

--- a/spec/factories/field.rb
+++ b/spec/factories/field.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
       label { nil }
       title { nil }
       hint { nil }
+      input_prefix { nil }
     end
 
     initialize_with do
@@ -40,6 +41,7 @@ FactoryBot.define do
       allow(field).to receive(:label).and_return(evaluator.label)
       allow(field).to receive(:title).and_return(evaluator.title)
       allow(field).to receive(:hint).and_return(evaluator.hint)
+      allow(field).to receive(:input_prefix).and_return(evaluator.input_prefix)
     end
   end
 end

--- a/spec/unit/app/models/edition/diffable_spec.rb
+++ b/spec/unit/app/models/edition/diffable_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe Edition::Diffable do
         previous_edition.details = {
           "rates" => {
             "rate-1" => {
-              "amount" => "£124.55",
+              "amount" => "124.55",
               "frequency" => "a week",
             },
             "other-rate" => {
-              "amount" => "£5",
+              "amount" => "5",
               "frequency" => "a week",
             },
           },
@@ -83,11 +83,11 @@ RSpec.describe Edition::Diffable do
         edition.details = {
           "rates" => {
             "rate-1" => {
-              "amount" => "£124.22",
+              "amount" => "124.22",
               "frequency" => "a week",
             },
             "rate-2" => {
-              "amount" => "£99.50",
+              "amount" => "99.50",
               "frequency" => "a week",
             },
           },
@@ -99,14 +99,14 @@ RSpec.describe Edition::Diffable do
             "rates" => {
               "rate-1" => {
                 "amount" => DiffItem.new(
-                  previous_value: "£124.55",
-                  new_value: "£124.22",
+                  previous_value: "124.55",
+                  new_value: "124.22",
                 ),
 
               },
               "other-rate" => {
                 "amount" => DiffItem.new(
-                  previous_value: "£5",
+                  previous_value: "5",
                   new_value: nil,
                 ),
                 "frequency" => DiffItem.new(
@@ -117,7 +117,7 @@ RSpec.describe Edition::Diffable do
               "rate-2" => {
                 "amount" => DiffItem.new(
                   previous_value: nil,
-                  new_value: "£99.50",
+                  new_value: "99.50",
                 ),
                 "frequency" => DiffItem.new(
                   previous_value: nil,

--- a/spec/unit/app/models/schema/field/configuration_spec.rb
+++ b/spec/unit/app/models/schema/field/configuration_spec.rb
@@ -153,4 +153,25 @@ RSpec.describe Schema::Field::Configuration do
       end
     end
   end
+
+  describe "#input_prefix" do
+    context "when the body includes an `x-input-prefix` property" do
+      let(:body) do
+        { "properties" => { "something" => { "type" => "string", "x-input-prefix" => "£" } } }
+      end
+
+      it "returns the input prefix" do
+        expect(field.input_prefix).to eq("£")
+      end
+    end
+
+    context "when the body does not include an `x-input-prefix` property" do
+      let(:body) do
+        { "properties" => { "something" => { "type" => "string" } } }
+      end
+      it "returns nil" do
+        expect(field.input_prefix).to be_nil
+      end
+    end
+  end
 end

--- a/spec/unit/app/public/domain/block_content_spec.rb
+++ b/spec/unit/app/public/domain/block_content_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BlockContent do
                 "my_rate" => {
                   "title" => "my title",
                   "frequency" => "weekly",
-                  "amount" => "£1000",
+                  "amount" => "1000",
                 },
               },
             })
@@ -42,7 +42,7 @@ RSpec.describe BlockContent do
 
     describe "#fields" do
       it "should return the fields defined as block-level (display) fields" do
-        expect(block_content.fields("my_rate")).to eq({ "amount" => "£1000" })
+        expect(block_content.fields("my_rate")).to eq({ "amount" => "1000" })
       end
 
       context "when block is not defined" do

--- a/spec/unit/app/public/domain/metadata_row_ordering_rule_spec.rb
+++ b/spec/unit/app/public/domain/metadata_row_ordering_rule_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe MetadataRowOrderingRule do
   let(:dummy_metadata) do
     [
-      { field: "amount", value: "£1000" },
+      { field: "amount", value: "1000" },
       { field: "title", value: "My Title" },
       { field: "frequency", value: "weekly" },
     ]
@@ -17,7 +17,7 @@ RSpec.describe MetadataRowOrderingRule do
         expect(sorted_metadata)
           .to eq([{ field: "frequency", value: "weekly" },
                   { field: "title", value: "My Title" },
-                  { field: "amount", value: "£1000" }])
+                  { field: "amount", value: "1000" }])
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe MetadataRowOrderingRule do
       it "should order by title first, then as-provided" do
         expect(sorted_metadata)
           .to eq([{ field: "title", value: "My Title" },
-                  { field: "amount", value: "£1000" },
+                  { field: "amount", value: "1000" },
                   { field: "frequency", value: "weekly" }])
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe MetadataRowOrderingRule do
     context "when field is named in uppercase" do
       let(:dummy_metadata) do
         [
-          { field: "AMOUNT", value: "£1000" },
+          { field: "AMOUNT", value: "1000" },
           { field: "TITLE", value: "My Title" },
           { field: "FREQUENCY", value: "weekly" },
         ]
@@ -47,7 +47,7 @@ RSpec.describe MetadataRowOrderingRule do
           expect(sorted_metadata)
             .to eq([{ field: "FREQUENCY", value: "weekly" },
                     { field: "TITLE", value: "My Title" },
-                    { field: "AMOUNT", value: "£1000" }])
+                    { field: "AMOUNT", value: "1000" }])
         end
       end
 
@@ -57,7 +57,7 @@ RSpec.describe MetadataRowOrderingRule do
         it "should be case insensitive when ordering by title" do
           expect(sorted_metadata)
             .to eq([{ field: "TITLE", value: "My Title" },
-                    { field: "AMOUNT", value: "£1000" },
+                    { field: "AMOUNT", value: "1000" },
                     { field: "FREQUENCY", value: "weekly" }])
         end
       end

--- a/spec/unit/app/validators/details_validator/pension_spec.rb
+++ b/spec/unit/app/validators/details_validator/pension_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DetailsValidator do
   describe "pension schema" do
     let(:document) { build(:document, :pension) }
 
-    let(:amount) { "£320.00" }
+    let(:amount) { "320.00" }
     let(:frequency) { "a week" }
 
     let(:rate) do
@@ -36,7 +36,7 @@ RSpec.describe DetailsValidator do
     end
 
     context "when the amount does not have a decimal point" do
-      let(:amount) { "£320" }
+      let(:amount) { "320" }
 
       it { is_expected.to be_valid }
     end

--- a/spec/unit/lib/tasks/remove_pound_symbol_prefix_from_pension_amount_value_spec.rb
+++ b/spec/unit/lib/tasks/remove_pound_symbol_prefix_from_pension_amount_value_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "data_migration:remove_pound_symbol_prefix_from_pension_amount_value" do
+  let(:task) { Rake::Task["data_migration:remove_pound_symbol_prefix_from_pension_amount_value"] }
+
+  let!(:document) { create(:document, block_type: :pension) }
+
+  after do
+    task.reenable
+  end
+
+  describe "when there is an edition with #amounts both with and without prefixes" do
+    let!(:pension_edition) do
+      create(
+        :edition,
+        document: document,
+        title: "Pension",
+        details: { "rates" => {
+          "rate_with_prefix" => { "amount" => "£221.20", "frequency" => "per week" },
+          "rate_without_prefix" => { "amount" => "132.50", "frequency" => "per week" },
+        } },
+      )
+    end
+
+    it "removes the pound symbol prefix from values that contain it" do
+      task.invoke
+
+      expect(pension_edition.reload.details["rates"]["rate_with_prefix"]).to eq(
+        { "amount" => "221.20", "frequency" => "per week" },
+      )
+    end
+
+    it "does not change values that do not contain the pound symbol prefix" do
+      task.invoke
+
+      expect(pension_edition.reload.details["rates"]["rate_without_prefix"]).to eq(
+        { "amount" => "132.50", "frequency" => "per week" },
+      )
+    end
+  end
+end


### PR DESCRIPTION
Jira [CM-944](https://gov-uk.atlassian.net/browse/CM-944)

This PR makes breaking changes to the pension JSON schema, removing the expectation that the pension "amount" field will contain a "£" prefix and instead adding a "x-input-prefix" field to the pension schema amount field to pass through a configurable prefix separate from the value. This will allow us to make better and easier use of the pension value as a number (in e.g. pension calculations), as well as making use of the existing [input with a prefix GDS component](https://design-system.service.gov.uk/components/text-input/input-prefix-suffix/) in our pension block form (included within this PR).

### **As these are breaking changes, they should not be merged until we are satisfied that we have a plan for migrating existing pension amount values via a Rake task.**

Screenshot of changes:
<img width="967" height="652" alt="Screenshot 2026-05-28 at 11 52 27" src="https://github.com/user-attachments/assets/eb0e6020-034b-4d7c-b2a2-be9c67845ffd" />

## Checklist before merging

### Tools gem updates
Confirm that the following users of content_block_tools are running v.1.14 so they have the new [PensionRatePresenter](https://github.com/alphagov/govuk_content_block_tools/pull/160) which copes with both forms of rate:

"£100.30" and
"100.30":

- [x] Whitehall
- [x] Publisher
- [x] Publishing-API
- [x] Smart answers

## End to end test suites

Verify that both E2E suites will pass (or plan a sequence of expected failures and fixes):

- [x] GOV.UK E2E ([alphagov/govuk-e2e-tests](https://github.com/alphagov/govuk-e2e-tests/blob/main/tests/content-block-manager.spec.js))
- [x] Content Modelling E2E ([alphagov/content-modelling-e2e](https://github.com/alphagov/content-modelling-e2e/blob/main/tests/content-block-manager.spec.js))

[CM-944]: https://gov-uk.atlassian.net/browse/CM-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ