### PR TITLE
Validate base_path within BlockPreview to avoid SSRF attack

### DIFF
--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -9,6 +9,7 @@ module BlockPreview
     ERROR_HTML = "<html><head></head><body><p>Preview not found</p></body></html>".freeze
 
     class HtmlSnapshotError < StandardError; end
+    class UnsafePathError < StandardError; end
 
     def initialize(content_id:, block:, base_path:, locale:, state:, auth_bypass_id:)
       @content_id = content_id
@@ -30,7 +31,7 @@ module BlockPreview
       update_local_link_paths(nokogiri_html)
       update_local_form_actions(nokogiri_html, uri.scheme, uri.host)
       nokogiri_html.to_s
-    rescue HtmlSnapshotError
+    rescue HtmlSnapshotError, UnsafePathError
       ERROR_HTML
     end
 
@@ -39,7 +40,15 @@ module BlockPreview
     attr_reader :block, :content_id, :base_path, :locale, :state, :auth_bypass_id
 
     def frontend_path
-      frontend_base_path + base_path
+      clean_path = base_path.to_s.strip
+
+      invalid_sequences = ["@", "//", "\\"]
+
+      if !clean_path.start_with?("/") || invalid_sequences.any? { |seq| clean_path.include?(seq) }
+        raise UnsafePathError, "Unsafe path format"
+      end
+
+      frontend_base_path + clean_path
     end
 
     def frontend_base_path

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -170,6 +170,78 @@ RSpec.describe BlockPreview::PreviewHtml do
     end
   end
 
+  describe "path validation" do
+    let(:preview) do
+      BlockPreview::PreviewHtml.new(
+        content_id: host_content_id,
+        block: block_to_preview,
+        base_path: host_base_path,
+        locale: "en",
+        state: "published",
+        auth_bypass_id:,
+      )
+    end
+
+    context "when base_path is safe" do
+      let(:host_base_path) { "/test-path" }
+
+      it "constructs a safe frontend path" do
+        expect(preview.send(:frontend_path)).to eq("#{Plek.website_root}/test-path")
+      end
+
+      it "does not raise an argument error when calling to_s" do
+        expect { preview.to_s }.not_to raise_error
+      end
+    end
+
+    context "when base_path is unsafe" do
+      shared_examples "an unsafe path" do
+        it "raises an UnsafePathError when fetching the frontend path" do
+          expect { preview.send(:frontend_path) }.to raise_error(BlockPreview::PreviewHtml::UnsafePathError, "Unsafe path format")
+        end
+
+        it "returns the error HTML when calling to_s" do
+          expect(preview.to_s).to eq(BlockPreview::PreviewHtml::ERROR_HTML)
+        end
+
+        it "does not attempt to make a request to the frontend" do
+          preview.to_s
+          expect(Net::HTTP).not_to have_received(:get_response)
+        end
+      end
+
+      context "when it contains an @ symbol" do
+        let(:host_base_path) { "/test@example.com" }
+        it_behaves_like "an unsafe path"
+      end
+
+      context "when it contains //" do
+        let(:host_base_path) { "//attack.com" }
+        it_behaves_like "an unsafe path"
+      end
+
+      context "when it contains \\" do
+        let(:host_base_path) { "\\attack.com" }
+        it_behaves_like "an unsafe path"
+      end
+
+      context "when it does not start with /" do
+        let(:host_base_path) { "attack.com" }
+        it_behaves_like "an unsafe path"
+      end
+
+      context "when it is an absolute URL starting with http" do
+        let(:host_base_path) { "http://attack.com" }
+        it_behaves_like "an unsafe path"
+      end
+
+      context "when it is blank" do
+        let(:host_base_path) { "   " }
+        it_behaves_like "an unsafe path"
+      end
+    end
+  end
+
   describe "when the frontend response contains links" do
     let(:fake_content) do
       "


### PR DESCRIPTION
Until now we haven’t been validating the base_path within BlockPreview, which could in theory leave us open to a server-side request forgery attack that could expose a JWT token to an attacker. This basic defensive change should protect us from this possibility.