### PR TITLE
CM-983 Strengthen SSRF defences in block preview engine

### DIFF
--- a/engines/block_preview/app/model/block_preview/form_submission.rb
+++ b/engines/block_preview/app/model/block_preview/form_submission.rb
@@ -1,8 +1,10 @@
-# Represents a form submission to a gov.uk domain and its resulting behavior.
+# Represents a form submission to a GOV.UK frontend and its resulting
+# redirect behaviour. Only allows requests to known frontend hosts
+# as determined by Plek.
 #
 # @example Basic usage
 #   submission = FormSubmission.new(
-#     url: "https://example.gov.uk/form",
+#     url: "https://www.gov.uk/form",
 #     body: { field: "value" },
 #     method: "post"
 #   )
@@ -12,7 +14,7 @@ module BlockPreview
   class FormSubmission
     # @return [URI] The parsed URI of the target URL
     # @example
-    #   URI("https://example.gov.uk/form")
+    #   URI("https://www.gov.uk/form")
     attr_reader :uri
 
     # @return [Hash] The form data to be submitted
@@ -28,7 +30,7 @@ module BlockPreview
     # Raised when the HTTP response is not as expected
     class UnexpectedResponseError < StandardError; end
 
-    # Raised when the URL is not a gov.uk domain
+    # Raised when the URL host is not in the allowed frontend hosts
     class UnexpectedUrlError < StandardError; end
 
     # Initializes a new FormSubmission.
@@ -36,13 +38,14 @@ module BlockPreview
     # @param url [String] The target URL to submit the form to
     # @param body [Hash] The form data to be submitted
     # @param method [String] The HTTP method to use for the request
-    # @raise [UnexpectedUrlError] if the URL is not a gov.uk domain
+    # @raise [UnexpectedUrlError] if the URL host is not an allowed
+    #   frontend host
     #
     def initialize(url:, body:, method:)
       @uri = URI.parse(url)
       @body = body
       @method = method
-      raise UnexpectedUrlError unless uri.host&.ends_with?("gov.uk")
+      raise UnexpectedUrlError unless allowed_host?
     end
 
     # The path component of the redirect location resulting from the submission.
@@ -59,7 +62,18 @@ module BlockPreview
       location.request_uri
     end
 
+    def self.allowed_hosts
+      [
+        Plek.website_root,
+        Plek.external_url_for("draft-origin"),
+      ].map { |url| URI.parse(url).host }.compact.uniq
+    end
+
   private
+
+    def allowed_host?
+      self.class.allowed_hosts.include?(uri.host)
+    end
 
     def http_uri?(uri)
       uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -96,13 +96,20 @@ module BlockPreview
     end
 
     def html_snapshot_from_frontend(uri)
+      verify_trusted_host!(uri)
       uri = add_auth_bypass_token_to_uri(uri) if draft?
-      # Net::HTTP.get_response doesn't work with Addressable::URI, so we need to convert it to a standard URI
       response = Net::HTTP.get_response(URI.parse(uri.to_s))
       if response.code == "200"
         Nokogiri::HTML.parse(response.body)
       else
         raise HtmlSnapshotError
+      end
+    end
+
+    def verify_trusted_host!(uri)
+      expected_host = Addressable::URI.parse(frontend_origin).host
+      unless uri.host == expected_host
+        raise UnsafePathError, "Untrusted host"
       end
     end
 

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -48,22 +48,23 @@ module BlockPreview
         raise UnsafePathError, "Unsafe path format"
       end
 
-      frontend_base_path + clean_path
+      frontend_origin + clean_path
     end
 
-    def frontend_base_path
-      @frontend_base_path ||= Rails.env.development? ? development_base_path : website_base_root
+    def frontend_origin
+      @frontend_origin ||= Rails.env.development? ? development_origin : website_origin
     end
 
-    def website_base_root
+    def website_origin
       draft? ? Plek.external_url_for("draft-origin") : Plek.website_root
     end
 
-    # There are multiple rendering apps for GOV.UK. In non-dev environments, the Router app determines the rendering app
-    # to use. We don't have access to this in dev, so we need to get the rendering app from the Publishing API and construct
-    # the base path that way.
-    def development_base_path
-      @development_base_path ||= begin
+    # There are multiple rendering apps for GOV.UK. In non-dev environments,
+    # the Router app determines the rendering app to use. We don't have access
+    # to this in dev, so we need to get the rendering app from the Publishing
+    # API and construct the origin that way.
+    def development_origin
+      @development_origin ||= begin
         publishing_api_response ||= Public::Services.publishing_api.get_content(content_id)
         Plek.external_url_for(rendering_app(publishing_api_response))
       end
@@ -136,7 +137,7 @@ module BlockPreview
     def update_css_hrefs(nokogiri_html)
       head = nokogiri_html.at_css("head")
       head.css("link[rel='stylesheet']").each do |link|
-        link[:href] = frontend_base_path + link[:href] if link[:href]
+        link[:href] = frontend_origin + link[:href] if link[:href]
       end
       nokogiri_html
     end
@@ -144,7 +145,7 @@ module BlockPreview
     def update_js_srcs(nokogiri_html)
       head = nokogiri_html.at_css("head")
       head.css("script").each do |script|
-        script[:src] = frontend_base_path + script[:src] if script[:src]
+        script[:src] = frontend_origin + script[:src] if script[:src]
       end
       nokogiri_html
     end

--- a/engines/block_preview/app/model/block_preview/preview_html.rb
+++ b/engines/block_preview/app/model/block_preview/preview_html.rb
@@ -21,7 +21,7 @@ module BlockPreview
     end
 
     def to_s
-      uri = Addressable::URI.parse(frontend_path)
+      uri = frontend_uri
       nokogiri_html = html_snapshot_from_frontend(uri)
       add_draft_style(nokogiri_html)
       update_css_hrefs(nokogiri_html)
@@ -39,16 +39,27 @@ module BlockPreview
 
     attr_reader :block, :content_id, :base_path, :locale, :state, :auth_bypass_id
 
-    def frontend_path
-      clean_path = base_path.to_s.strip
-
-      invalid_sequences = ["@", "//", "\\"]
-
-      if !clean_path.start_with?("/") || invalid_sequences.any? { |seq| clean_path.include?(seq) }
-        raise UnsafePathError, "Unsafe path format"
+    def frontend_uri
+      validate_base_path!
+      uri = Addressable::URI.parse(frontend_origin)
+      expected_host = uri.host
+      uri.path = base_path.to_s.strip
+      uri.query = nil
+      uri.fragment = nil
+      unless uri.host == expected_host
+        raise UnsafePathError, "URI host mismatch"
       end
 
-      frontend_origin + clean_path
+      uri
+    end
+
+    def validate_base_path!
+      clean_path = base_path.to_s.strip
+      invalid_sequences = %w[@ // \\]
+      if !clean_path.start_with?("/") ||
+          invalid_sequences.any? { |seq| clean_path.include?(seq) }
+        raise UnsafePathError, "Unsafe path format"
+      end
     end
 
     def frontend_origin

--- a/engines/block_preview/spec/unit/app/models/form_submission_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/form_submission_spec.rb
@@ -1,55 +1,70 @@
 RSpec.describe BlockPreview::FormSubmission do
-  let(:valid_url) { "https://example.gov.uk/form" }
   let(:body) { { field: "value", another_field: "data" } }
   let(:method) { "post" }
 
+  let(:website_host) { URI.parse(Plek.website_root).host }
+  let(:draft_host) { URI.parse(Plek.external_url_for("draft-origin")).host }
+
   describe "#initialize" do
-    context "with a valid gov.uk URL" do
-      it "successfully creates an instance" do
-        service = described_class.new(url: valid_url, body: body, method:)
+    context "with an allowed frontend host" do
+      it "accepts the live frontend host" do
+        url = "http://#{website_host}/form"
+        service = described_class.new(url: url, body: body, method:)
         expect(service).to be_a(BlockPreview::FormSubmission)
       end
-    end
 
-    context "with a subdomain of gov.uk" do
-      it "accepts the URL" do
-        url = "https://subdomain.example.gov.uk/path"
+      it "accepts the draft frontend host" do
+        url = "http://#{draft_host}/form"
+        service = described_class.new(url: url, body: body, method:)
+        expect(service).to be_a(BlockPreview::FormSubmission)
+      end
+
+      it "accepts paths with query parameters" do
+        url = "http://#{website_host}/form?param=value"
         service = described_class.new(url: url, body: body, method:)
         expect(service).to be_a(BlockPreview::FormSubmission)
       end
     end
 
-    context "with an invalid URL" do
-      it "raises UnexpectedUrlError for non-gov.uk domains" do
-        invalid_url = "https://example.com/form"
+    context "with a disallowed host" do
+      it "rejects arbitrary external domains" do
         expect {
-          described_class.new(url: invalid_url, body: body, method:)
+          described_class.new(
+            url: "https://evil.com/form", body: body, method:,
+          )
         }.to raise_error(BlockPreview::FormSubmission::UnexpectedUrlError)
       end
 
-      it "raises UnexpectedUrlError for URLs that contain but don't end with gov.uk" do
-        invalid_url = "https://gov.uk.fake.com/form"
+      it "rejects other gov.uk subdomains not in the allowlist" do
         expect {
-          described_class.new(url: invalid_url, body: body, method:)
+          described_class.new(
+            url: "https://other-service.gov.uk/form",
+            body: body, method:
+          )
         }.to raise_error(BlockPreview::FormSubmission::UnexpectedUrlError)
       end
-    end
 
-    context "with a URL without a domain" do
-      it "raises UnexpectedUrlError domains" do
-        invalid_url = "form"
+      it "rejects hosts that merely contain an allowed host" do
         expect {
-          described_class.new(url: invalid_url, body: body, method:)
+          described_class.new(
+            url: "https://#{website_host}.evil.com/form",
+            body: body, method:
+          )
+        }.to raise_error(BlockPreview::FormSubmission::UnexpectedUrlError)
+      end
+
+      it "rejects URLs without a host" do
+        expect {
+          described_class.new(url: "form", body: body, method:)
         }.to raise_error(BlockPreview::FormSubmission::UnexpectedUrlError)
       end
     end
   end
 
   describe "#redirect_path" do
+    let(:valid_url) { "http://#{website_host}/form" }
     let(:service) { described_class.new(url: valid_url, body: body, method:) }
-    let(:response) { double(code: response_code, headers: { "location" => redirect_location }) }
-
-    let(:redirect_location) { "https://example.gov.uk/preview/123" }
+    let(:redirect_location) { "https://#{website_host}/preview/123" }
 
     before do
       stub_request(:post, valid_url)
@@ -89,10 +104,12 @@ RSpec.describe BlockPreview::FormSubmission do
     end
 
     context "when response has a redirect with query parameters" do
-      let(:redirect_location) { "https://example.gov.uk/preview/123?param=value" }
+      let(:redirect_location) do
+        "https://#{website_host}/preview/123?param=value"
+      end
       let(:response_code) { 302 }
 
-      it "returns only the path without query parameters" do
+      it "includes query parameters in the returned path" do
         expect(service.redirect_path).to eq("/preview/123?param=value")
       end
     end
@@ -136,6 +153,20 @@ RSpec.describe BlockPreview::FormSubmission do
           service.redirect_path
         }.to raise_error(BlockPreview::FormSubmission::UnexpectedResponseError)
       end
+    end
+  end
+
+  describe ".allowed_hosts" do
+    it "includes the live frontend host" do
+      expect(described_class.allowed_hosts).to include(website_host)
+    end
+
+    it "includes the draft frontend host" do
+      expect(described_class.allowed_hosts).to include(draft_host)
+    end
+
+    it "does not include arbitrary hosts" do
+      expect(described_class.allowed_hosts).not_to include("evil.com")
     end
   end
 end

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe BlockPreview::PreviewHtml do
     expect(content_diff_spy).to have_received(:to_s)
   end
 
-  it "appends the base path to the CSS and JS references" do
+  it "prepends the frontend origin to the CSS and JS references" do
     actual_content = BlockPreview::PreviewHtml.new(
       content_id: host_content_id,
       block: block_to_preview,
@@ -443,7 +443,7 @@ RSpec.describe BlockPreview::PreviewHtml do
       expect(content_diff_spy).to have_received(:to_s)
     end
 
-    it "appends the draft-origin base path to the CSS and JS references" do
+    it "prepends the draft origin to the CSS and JS references" do
       parsed_content = Nokogiri::HTML.parse(actual_content)
 
       expect(parsed_content.at_css("link[href='#{Plek.external_url_for('draft-origin')}/assets/application.css']")).to be_present

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -267,6 +267,55 @@ RSpec.describe BlockPreview::PreviewHtml do
           )
         end
       end
+
+      context "if input validation is somehow bypassed" do
+        before { allow(preview).to receive(:validate_base_path!) }
+
+        context "with base path set to original attack vector (@ as userinfo delimiter)" do
+          let(:host_base_path) { "/@evil.example.com/" }
+
+          it "URI component assignment prevents host hijacking" do
+            expected_host = Addressable::URI.parse(Plek.website_root).host
+
+            uri = preview.send(:frontend_uri)
+
+            expect(uri.host).to eq(expected_host)
+            expect(uri.path).to eq("/@evil.example.com/")
+          end
+        end
+
+        context "with base path set to a protocol-relative path" do
+          let(:host_base_path) { "//evil.example.com/" }
+
+          it "URI component assignment prevents host hijacking" do
+            expected_host = Addressable::URI.parse(Plek.website_root).host
+
+            uri = preview.send(:frontend_uri)
+
+            expect(uri.host).to eq(expected_host)
+          end
+        end
+
+        context "if path assignment is somehow able to mutate the URI host" do
+          it "raises UnsafePathError" do
+            origin = preview.send(:frontend_origin)
+            uri = Addressable::URI.parse(origin)
+
+            allow(uri).to receive(:path=) do
+              allow(uri).to receive(:host).and_return(
+                "evil.example.com",
+              )
+            end
+            allow(Addressable::URI).to receive(:parse)
+              .with(origin).and_return(uri)
+
+            expect { preview.send(:frontend_uri) }.to raise_error(
+              BlockPreview::PreviewHtml::UnsafePathError,
+              "URI host mismatch",
+            )
+          end
+        end
+      end
     end
 
     describe "trusted host verification before request" do

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -185,19 +185,26 @@ RSpec.describe BlockPreview::PreviewHtml do
     context "when base_path is safe" do
       let(:host_base_path) { "/test-path" }
 
-      it "constructs a safe frontend path" do
-        expect(preview.send(:frontend_path)).to eq("#{Plek.website_root}/test-path")
+      it "constructs a URI with the expected origin and path" do
+        uri = preview.send(:frontend_uri)
+        expect(uri).to be_a(Addressable::URI)
+        expect(uri.host).to eq(
+          Addressable::URI.parse(Plek.website_root).host,
+        )
+        expect(uri.path).to eq("/test-path")
       end
 
-      it "does not raise an argument error when calling to_s" do
+      it "does not raise an error when calling to_s" do
         expect { preview.to_s }.not_to raise_error
       end
     end
 
     context "when base_path is unsafe" do
       shared_examples "an unsafe path" do
-        it "raises an UnsafePathError when fetching the frontend path" do
-          expect { preview.send(:frontend_path) }.to raise_error(BlockPreview::PreviewHtml::UnsafePathError, "Unsafe path format")
+        it "raises an UnsafePathError" do
+          expect { preview.send(:frontend_uri) }.to raise_error(
+            BlockPreview::PreviewHtml::UnsafePathError,
+          )
         end
 
         it "returns the error HTML when calling to_s" do
@@ -238,6 +245,27 @@ RSpec.describe BlockPreview::PreviewHtml do
       context "when it is blank" do
         let(:host_base_path) { "   " }
         it_behaves_like "an unsafe path"
+      end
+    end
+
+    describe "origin verification" do
+      it "verifies the constructed URI host matches the expected origin" do
+        uri = preview.send(:frontend_uri)
+        expected_host = Addressable::URI.parse(Plek.website_root).host
+        expect(uri.host).to eq(expected_host)
+      end
+
+      context "when base_path contains @" do
+        it "does not allow @ to be interpreted as a userinfo delimiter that changes the host" do
+          origin = Addressable::URI.parse(Plek.website_root)
+          origin.path = "/@evil.example.com/"
+          expect(origin.host).to eq(
+            Addressable::URI.parse(Plek.website_root).host,
+          )
+          expect(origin.to_s).to eq(
+            "#{Plek.website_root}/@evil.example.com/",
+          )
+        end
       end
     end
   end

--- a/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
+++ b/engines/block_preview/spec/unit/app/models/preview_html_spec.rb
@@ -268,6 +268,34 @@ RSpec.describe BlockPreview::PreviewHtml do
         end
       end
     end
+
+    describe "trusted host verification before request" do
+      it "rejects a URI with an untrusted host" do
+        untrusted_uri = Addressable::URI.parse("https://evil.com/path")
+        expect {
+          preview.send(:verify_trusted_host!, untrusted_uri)
+        }.to raise_error(
+          BlockPreview::PreviewHtml::UnsafePathError, "Untrusted host"
+        )
+      end
+
+      it "accepts a URI with the expected frontend host" do
+        trusted_uri = Addressable::URI.parse(
+          "#{Plek.website_root}/some-path",
+        )
+        expect {
+          preview.send(:verify_trusted_host!, trusted_uri)
+        }.not_to raise_error
+      end
+
+      it "does not append the auth token when host is untrusted" do
+        untrusted_uri = Addressable::URI.parse("https://evil.com/path")
+        expect(JWT).not_to receive(:encode)
+        expect {
+          preview.send(:html_snapshot_from_frontend, untrusted_uri)
+        }.to raise_error(BlockPreview::PreviewHtml::UnsafePathError)
+      end
+    end
   end
 
   describe "when the frontend response contains links" do


### PR DESCRIPTION
## Strengthen SSRF defences in block preview engine

[PR #720 (merged 12 Jun)](https://github.com/alphagov/content-block-manager/pull/720) added an initial fix for a reported SSRF vulnerability in the block_preview engine. That fix introduced a denylist (`@, //, \`) to reject dangerous `base_path` values before URL construction.

This PR builds on that work with structural improvements which should make the vulnerability class impossible.

1. Rename `frontend_base_path` to `frontend_origin`

2. Replace string concatenation with URI component assignment 

3. Verify trusted host before attaching credentials This ensures credentials are never sent to an untrusted host, even if earlier validation were bypassed in a future refactoring.

4. Replace `FormSubmission` domain check with explicit host allowlist

See individual commits for more detail.