### PR TITLE
Fix API query

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -29,6 +29,10 @@ class Edition < ApplicationRecord
     where(updated_at: Edition.active.select("MAX(updated_at)").group(:document_id))
   }
 
+  scope :most_recent_published_for_document, lambda {
+    where(editions: { id: Edition.published.select("MAX(id)").group(:document_id) })
+  }
+
   scope :most_recent_first, lambda {
     order(updated_at: :desc)
   }

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -13,7 +13,7 @@ class ContentBlock
 
     def results
       Result.new(
-        blocks: paginated_results.map { |document| ContentBlock.new(document.most_recent_edition) },
+        blocks: paginated_results.map { |document| ContentBlock.new(document.latest_published_edition) },
         current_page: paginated_results.current_page,
         total_pages: paginated_results.total_pages,
         total_count: paginated_results.total_count,
@@ -34,8 +34,8 @@ class ContentBlock
 
     def unpaginated_results
       Document.joins(:editions)
-              .merge(Edition.most_recent_for_document)
               .merge(Edition.published)
+              .merge(Edition.most_recent_published_for_document)
               .extending(Scopes)
               .by_block_type(filters[:block_type])
               .by_lead_organisation_id(filters[:lead_organisation_id])

--- a/spec/unit/app/models/edition/scopes_spec.rb
+++ b/spec/unit/app/models/edition/scopes_spec.rb
@@ -38,4 +38,29 @@ RSpec.describe Edition do
       end
     end
   end
+  describe ".most_recent_published_for_document" do
+    let(:document) { create(:document) }
+
+    context "where there are multiple draft and published editions" do
+      before do
+        create(:edition, document: document, updated_at: Time.zone.now - 2.days, state: :published)
+        create(:edition, document: document, updated_at: Time.zone.now, state: :draft)
+      end
+
+      let!(:most_recent_published_edition) { create(:edition, document: document, updated_at: Time.zone.now - 1.day, state: :published) }
+      it "returns the most recent published edition" do
+        expect(Edition.most_recent_published_for_document).to eq([most_recent_published_edition])
+      end
+    end
+
+    context "where there are only draft editions" do
+      before do
+        create(:edition, document: document, state: :draft)
+        create(:edition, document: document, state: :draft)
+      end
+      it "returns an empty list" do
+        expect(Edition.most_recent_published_for_document).to eq([])
+      end
+    end
+  end
 end

--- a/spec/unit/app/public/queries/content_block/query_spec.rb
+++ b/spec/unit/app/public/queries/content_block/query_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ContentBlock::Query do
 
     it "excludes draft content blocks" do
       doc_a = create(:document)
-      create(:edition, :published, document: doc_a, title: "Doc A published edition")
+      create(:edition, :published, document: doc_a, title: "Doc A published edition", created_at: 1.day.ago)
       create(:edition, :draft, document: doc_a, title: "Doc A draft edition")
 
       doc_b = create(:document)


### PR DESCRIPTION
We have had a flaky query spec unit test that is symptomatic of an error in our query implementation, and has been sporadically blocking our CI pipeline. Until now the chaining of  `.merge(Edition.most_recent_for_document).merge(Edition.published)` has meant that a Document is excluded entirely from the results if its most recent Edition is not published (i.e. is in draft).

To address this I’ve added a new method on the Edition class to get the most recent published document, and ensured that in the results method we are returning the latest *published* edition, rather than the most recent edition.