### PR TITLE
Remove unnecessary `merge(Edition.published)` call

### DIFF
--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -34,7 +34,6 @@ class ContentBlock
 
     def unpaginated_results
       Document.joins(:editions)
-              .merge(Edition.published)
               .merge(Edition.most_recent_published_for_document)
               .extending(Scopes)
               .by_block_type(filters[:block_type])


### PR DESCRIPTION
I left this in in a recent PR fixing this query. The query works as intended with or without it but it’s unnecessary because filtering out non-published editions is handled by `most_recent_published_for_document`.