### PR TITLE
Fix TimePeriod#date_range validation of day/months 08 and 09

### DIFF
--- a/app/public/domain/date_and_time/field_values.rb
+++ b/app/public/domain/date_and_time/field_values.rb
@@ -29,7 +29,7 @@ module DateAndTime
     def parse_integer(value)
       return nil if value.blank?
 
-      Integer(value)
+      Integer(value, 10)
     rescue ArgumentError
       nil
     end

--- a/spec/unit/app/controllers/concerns/date_range_validator_spec.rb
+++ b/spec/unit/app/controllers/concerns/date_range_validator_spec.rb
@@ -114,6 +114,35 @@ RSpec.describe DateRangeValidator do
       end
     end
 
+    context "when month or day is 08 or 09 (leading zero with non-octal digit)" do
+      let(:params) do
+        {
+          "start(1i)" => "2027",
+          "start(2i)" => "09",
+          "start(3i)" => "09",
+          "start(4i)" => "00",
+          "start(5i)" => "00",
+          "end(1i)" => "2028",
+          "end(2i)" => "09",
+          "end(3i)" => "08",
+          "end(4i)" => "23",
+          "end(5i)" => "59",
+        }
+      end
+
+      it "accepts the dates as valid" do
+        expect { DateRangeValidator.new(edition, params).validate_and_convert }
+          .not_to raise_error
+      end
+
+      it "returns valid ISO 8601 datetimes" do
+        result = DateRangeValidator.new(edition, params).validate_and_convert
+
+        expect(result["start"]).to match(/\A2027-09-09T00:00:00[+-]\d{2}:\d{2}\z/)
+        expect(result["end"]).to match(/\A2028-09-08T23:59:00[+-]\d{2}:\d{2}\z/)
+      end
+    end
+
     context "when end datetime is not after start datetime" do
       let(:params) do
         {


### PR DESCRIPTION
We discovered that some datetimes where the day or the month starts with 08 or 09 were incorrectly being rejected as invalid.

This is because `FieldValues#parse_integer` used `Integer(value)` which interprets leading-zero strings as octal. Since 8 and 9 are not valid octal digits, `Integer("08")` and `Integer("09")` raise `ArgumentError`, causing:

- any datetime in the months of August or September, and
- any datetime using the day of the month 07 or 08

to be rejected as invalid.

The fix is when converting the given string to specify base 10 explicitly with `Integer(value, 10)`.