### PR TITLE
(CM-949) Initial ActiveRecord models

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,0 +1,5 @@
+module Block
+  def self.table_name_prefix
+    "block_"
+  end
+end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -3,7 +3,18 @@ module Block
     extend FriendlyId
     friendly_id :sluggable_string, use: :slugged, slug_column: :content_id_alias, routes: :default
 
-    has_many :editions, class_name: "Block::Edition", foreign_key: :block_document_id, dependent: :destroy
+    has_many :editions,
+             class_name: "Block::Edition",
+             foreign_key: :block_document_id,
+             dependent: :destroy,
+             inverse_of: :document
+
+    has_many :time_period_editions,
+             -> { where(type: "Block::TimePeriodEdition") },
+             class_name: "Block::TimePeriodEdition",
+             foreign_key: :block_document_id,
+             dependent: :destroy,
+             inverse_of: :document
 
     before_validation :generate_content_id, on: :create
     after_validation :set_content_id_alias_and_embed_code, on: :create

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -1,0 +1,30 @@
+module Block
+  class Document < ApplicationRecord
+    extend FriendlyId
+    friendly_id :sluggable_string, use: :slugged, slug_column: :content_id_alias, routes: :default
+
+    has_many :editions, class_name: "Block::Edition", foreign_key: :block_document_id, dependent: :destroy
+
+    before_validation :generate_content_id, on: :create
+    after_validation :set_content_id_alias_and_embed_code, on: :create
+
+    def built_embed_code
+      "{{embed:content_block_#{block_type}:#{content_id_alias}}}"
+    end
+
+    def embed_code_for_field(field_path)
+      "{{embed:content_block_#{block_type}:#{content_id_alias}/#{field_path}}}"
+    end
+
+  private
+
+    def generate_content_id
+      self.content_id ||= SecureRandom.uuid
+    end
+
+    def set_content_id_alias_and_embed_code
+      self.content_id_alias = friendly_id
+      self.embed_code = built_embed_code
+    end
+  end
+end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -8,6 +8,10 @@ module Block
     before_validation :generate_content_id, on: :create
     after_validation :set_content_id_alias_and_embed_code, on: :create
 
+    def title
+      editions.order(created_at: :desc).first&.title
+    end
+
     def built_embed_code
       "{{embed:content_block_#{block_type}:#{content_id_alias}}}"
     end

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -1,0 +1,15 @@
+module Block
+  class Edition < ApplicationRecord
+    include ::Edition::HasLeadOrganisation
+
+    belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id
+
+    validates :title, presence: true
+
+    # Abstract method to be implemented by subclasses
+    # Returns a hash representation of the edition's details
+    def to_details
+      raise NotImplementedError, "Subclasses must implement #to_details method"
+    end
+  end
+end

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -2,14 +2,31 @@ module Block
   class Edition < ApplicationRecord
     include ::Edition::HasLeadOrganisation
 
-    belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id
+    belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id, inverse_of: :editions
 
     validates :title, presence: true
+    validate :title_contains_alphanumeric_chars
+
+    before_validation :set_document_sluggable_string, on: :create
 
     # Abstract method to be implemented by subclasses
     # Returns a hash representation of the edition's details
     def to_details
       raise NotImplementedError, "Subclasses must implement #to_details method"
+    end
+
+  private
+
+    def set_document_sluggable_string
+      return unless document.present? && document.new_record?
+
+      document.sluggable_string = title if document.sluggable_string.blank?
+    end
+
+    def title_contains_alphanumeric_chars
+      if title.present? && title !~ /[a-z0-9]+/i
+        errors.add(:title, :alphanumeric)
+      end
     end
   end
 end

--- a/app/models/block/time_period_date_range.rb
+++ b/app/models/block/time_period_date_range.rb
@@ -2,6 +2,9 @@ module Block
   class TimePeriodDateRange < ApplicationRecord
     belongs_to :edition, class_name: "Block::TimePeriodEdition"
 
+    include DateValidation
+    date_attributes :start, :end
+
     validates :start, presence: true
     validates :end, presence: true
     validate :end_date_after_start_date

--- a/app/models/block/time_period_date_range.rb
+++ b/app/models/block/time_period_date_range.rb
@@ -1,0 +1,26 @@
+module Block
+  class TimePeriodDateRange < ApplicationRecord
+    belongs_to :edition, class_name: "Block::TimePeriodEdition"
+
+    validates :start, presence: true
+    validates :end, presence: true
+    validate :end_date_after_start_date
+
+    def to_details
+      {
+        "start" => start,
+        "end" => self.end,
+      }
+    end
+
+  private
+
+    def end_date_after_start_date
+      return if self.end.blank? || start.blank?
+
+      if self.end <= start
+        errors.add(:end, "must be after start date")
+      end
+    end
+  end
+end

--- a/app/models/block/time_period_edition.rb
+++ b/app/models/block/time_period_edition.rb
@@ -1,0 +1,4 @@
+module Block
+  class TimePeriodEdition < Edition
+  end
+end

--- a/app/models/block/time_period_edition.rb
+++ b/app/models/block/time_period_edition.rb
@@ -1,4 +1,7 @@
 module Block
   class TimePeriodEdition < Edition
+    has_one :date_range, class_name: "Block::TimePeriodDateRange", foreign_key: :edition_id, dependent: :destroy
+
+    accepts_nested_attributes_for :date_range
   end
 end

--- a/app/models/block/time_period_edition.rb
+++ b/app/models/block/time_period_edition.rb
@@ -3,5 +3,12 @@ module Block
     has_one :date_range, class_name: "Block::TimePeriodDateRange", foreign_key: :edition_id, dependent: :destroy
 
     accepts_nested_attributes_for :date_range
+
+    def to_details
+      {
+        "description" => description,
+        "date_range" => date_range&.to_details,
+      }.compact
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,14 @@ en:
               alphanumeric: "must contain at least one letter or number"
             lead_organisation_id:
               blank: "cannot be blank"
+        block/time_period_date_range:
+          attributes:
+            start:
+              blank: "Enter a start date"
+              invalid_date: "Start date is not a valid date"
+            end:
+              blank: "Enter an end date"
+              invalid_date: "End date is not a valid date"
     attributes:
       edition/document:
         title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,13 @@ en:
               invalid: "Start is invalid"
             end:
               invalid: "End is invalid"
+        block/edition:
+          attributes:
+            title:
+              blank: "cannot be blank"
+              alphanumeric: "must contain at least one letter or number"
+            lead_organisation_id:
+              blank: "cannot be blank"
     attributes:
       edition/document:
         title:

--- a/db/migrate/20260708153910_create_block_documents.rb
+++ b/db/migrate/20260708153910_create_block_documents.rb
@@ -1,0 +1,15 @@
+class CreateBlockDocuments < ActiveRecord::Migration[8.1]
+  def change
+    create_table :block_documents do |t|
+      t.uuid :content_id
+      t.string :sluggable_string
+      t.string :content_id_alias
+      t.string :block_type
+      t.datetime :deleted_at
+      t.string :embed_code
+      t.boolean :testing_artefact
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260709134353_create_block_editions.rb
+++ b/db/migrate/20260709134353_create_block_editions.rb
@@ -1,0 +1,14 @@
+class CreateBlockEditions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :block_editions do |t|
+      t.references :block_document, null: false, foreign_key: true
+      t.string :type
+      t.string :title
+      t.text :description
+      t.text :instructions_to_publishers
+      t.uuid :lead_organisation_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260709152529_create_block_time_period_date_ranges.rb
+++ b/db/migrate/20260709152529_create_block_time_period_date_ranges.rb
@@ -1,0 +1,11 @@
+class CreateBlockTimePeriodDateRanges < ActiveRecord::Migration[8.1]
+  def change
+    create_table :block_time_period_date_ranges do |t|
+      t.references :edition, null: false, foreign_key: { to_table: :block_editions }
+      t.datetime :start
+      t.datetime :end
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_16_134808) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_08_153910) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "block_documents", force: :cascade do |t|
+    t.string "block_type"
+    t.uuid "content_id"
+    t.string "content_id_alias"
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at"
+    t.string "embed_code"
+    t.string "sluggable_string"
+    t.boolean "testing_artefact"
+    t.datetime "updated_at", null: false
+  end
 
   create_table "documents", force: :cascade do |t|
     t.text "block_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_153910) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_134353) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_153910) do
     t.string "sluggable_string"
     t.boolean "testing_artefact"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "block_editions", force: :cascade do |t|
+    t.bigint "block_document_id", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.text "instructions_to_publishers"
+    t.uuid "lead_organisation_id"
+    t.string "title"
+    t.string "type"
+    t.datetime "updated_at", null: false
+    t.index ["block_document_id"], name: "index_block_editions_on_block_document_id"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -134,6 +146,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_153910) do
     t.index ["item_type"], name: "index_versions_on_item_type"
   end
 
+  add_foreign_key "block_editions", "block_documents"
   add_foreign_key "domain_events", "documents"
   add_foreign_key "domain_events", "editions"
   add_foreign_key "domain_events", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_134353) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_152529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -36,6 +36,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_134353) do
     t.string "type"
     t.datetime "updated_at", null: false
     t.index ["block_document_id"], name: "index_block_editions_on_block_document_id"
+  end
+
+  create_table "block_time_period_date_ranges", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "edition_id", null: false
+    t.datetime "end"
+    t.datetime "start"
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_block_time_period_date_ranges_on_edition_id"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -147,6 +156,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_134353) do
   end
 
   add_foreign_key "block_editions", "block_documents"
+  add_foreign_key "block_time_period_date_ranges", "block_editions", column: "edition_id"
   add_foreign_key "domain_events", "documents"
   add_foreign_key "domain_events", "editions"
   add_foreign_key "domain_events", "users"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
 [
-  Dir[Rails.root.join("spec/factories/*.rb")],
+  Dir[Rails.root.join("spec/factories/**/*.rb")],
   Dir[Rails.root.join("engines/**/spec/factories/*.rb")],
 ].flatten.sort.each { |f| require f }

--- a/spec/factories/block/document.rb
+++ b/spec/factories/block/document.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :block_document, class: "Block::Document" do
+    sequence(:sluggable_string) { |n| "block-document-#{n}" }
+    block_type { "time_period" }
+    testing_artefact { false }
+
+    trait :with_time_period_edition do
+      after(:create) do |document|
+        create(:block_time_period_edition, block_document: document)
+      end
+    end
+  end
+end

--- a/spec/factories/block/time_period_date_range.rb
+++ b/spec/factories/block/time_period_date_range.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :block_time_period_date_range, class: "Block::TimePeriodDateRange" do
+    association :edition, factory: :block_time_period_edition
+    start { Time.zone.parse("2025-04-06 00:00") }
+    self.end { Time.zone.parse("2026-04-05 23:59") }
+  end
+end

--- a/spec/factories/block/time_period_edition.rb
+++ b/spec/factories/block/time_period_edition.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :block_time_period_edition, class: "Block::TimePeriodEdition" do
+    association :document, factory: :block_document, block_type: "time_period"
+    sequence(:title) { |n| "Time Period #{n}" }
+    description { "A time period description" }
+    lead_organisation_id { SecureRandom.uuid }
+  end
+end

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -1,4 +1,39 @@
 RSpec.describe Block::Document, type: :model do
+  let(:block_edition_with_details) do
+    Class.new(Block::Edition) do
+      def self.name
+        "Block::FooEdition"
+      end
+
+      def lead_organisation_id
+        SecureRandom.uuid
+      end
+    end
+  end
+
+  describe "associations" do
+    describe "#time_period_editions" do
+      it "builds a TimePeriodEdition with the correct type" do
+        document = build(:block_document, block_type: "time_period")
+        edition = document.time_period_editions.build(title: "Test")
+
+        expect(edition).to be_a(Block::TimePeriodEdition)
+        expect(edition.type).to eq("Block::TimePeriodEdition")
+      end
+
+      it "only returns TimePeriodEdition instances" do
+        document = create(:block_document, block_type: "time_period")
+        time_period = create(:block_time_period_edition, document: document)
+        other = block_edition_with_details.new(document: document, title: "Foo Edition").save!
+
+        expect(document.editions.count).to eq(2)
+        expect(document.time_period_editions.count).to eq(1)
+        expect(document.time_period_editions.first).to eq(time_period)
+        expect(document.time_period_editions).not_to include(other)
+      end
+    end
+  end
+
   describe "callbacks" do
     describe "generate_content_id" do
       it "generates a UUID for content_id before validation on create" do

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -62,4 +62,20 @@ RSpec.describe Block::Document, type: :model do
         .to eq("{{embed:content_block_time_period:current-tax-year/date_range/start/date}}")
     end
   end
+
+  describe "#title" do
+    it "returns the title from the most recent edition" do
+      document = create(:block_document, block_type: "time_period")
+      create(:block_time_period_edition, document: document, title: "First Edition", created_at: 1.day.ago)
+      create(:block_time_period_edition, document: document, title: "Latest Edition", created_at: Time.current)
+
+      expect(document.title).to eq("Latest Edition")
+    end
+
+    it "returns nil when there are no editions" do
+      document = create(:block_document, block_type: "time_period")
+
+      expect(document.title).to be_nil
+    end
+  end
 end

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe Block::Document, type: :model do
+  describe "callbacks" do
+    describe "generate_content_id" do
+      it "generates a UUID for content_id before validation on create" do
+        document = described_class.new(
+          sluggable_string: "test-block",
+          block_type: "time_period",
+        )
+        expect(document.content_id).to be_nil
+        document.valid?
+        expect(document.content_id).to be_present
+        uuid_pattern = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-/
+        expect(document.content_id)
+          .to match(/#{uuid_pattern}[0-9a-f]{4}-[0-9a-f]{12}\z/)
+      end
+
+      it "does not override an existing content_id" do
+        custom_uuid = SecureRandom.uuid
+        document = described_class.new(
+          content_id: custom_uuid,
+          sluggable_string: "test-block",
+          block_type: "time_period",
+        )
+        document.valid?
+        expect(document.content_id).to eq(custom_uuid)
+      end
+    end
+
+    describe "generate_embed_code" do
+      it "generates embed_code after validation on create using content_id_alias" do
+        document = described_class.new(
+          sluggable_string: "test-block",
+          block_type: "time_period",
+        )
+        expect(document.embed_code).to be_nil
+        document.valid?
+        expect(document.embed_code).to be_present
+        expect(document.embed_code).to eq("{{embed:content_block_time_period:test-block}}")
+      end
+    end
+  end
+
+  describe "#built_embed_code" do
+    it "returns the embed code format using content_id_alias" do
+      document = described_class.new(
+        sluggable_string: "current-tax-year",
+        block_type: "time_period",
+      )
+      document.valid? # triggers FriendlyId to set content_id_alias
+      expect(document.built_embed_code).to eq("{{embed:content_block_time_period:current-tax-year}}")
+    end
+  end
+
+  describe "#embed_code_for_field" do
+    it "returns the embed code format for a specific field using content_id_alias" do
+      document = described_class.new(
+        sluggable_string: "current-tax-year",
+        block_type: "time_period",
+      )
+      document.valid? # triggers FriendlyId to set content_id_alias
+      expect(document.embed_code_for_field("date_range/start/date"))
+        .to eq("{{embed:content_block_time_period:current-tax-year/date_range/start/date}}")
+    end
+  end
+end

--- a/spec/unit/app/models/block/edition_spec.rb
+++ b/spec/unit/app/models/block/edition_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Block::Edition, type: :model do
+  # Since Edition is abstract, we need a concrete subclass for testing
+  let(:concrete_edition_class) do
+    Class.new(Block::Edition) do
+      def self.name
+        "Block::OtherTypeEdition"
+      end
+
+      def to_details
+        { "field_1" => "value 1" }
+      end
+    end
+  end
+
+  # Another concrete subclass, this one missing the #to_details implementation
+  let(:edition_class_missing_implementation) do
+    Class.new(Block::Edition) do
+      def self.name
+        "Block::MissingImplementationEdition"
+      end
+    end
+  end
+
+  describe "associations" do
+    subject { concrete_edition_class.new(title: "Other Type Title") }
+    it { is_expected.to belong_to(:document).class_name("Block::Document") }
+  end
+
+  describe "validations" do
+    subject { concrete_edition_class.new(title: "Other Type Title") }
+    it { is_expected.to validate_presence_of(:title) }
+  end
+
+  describe "#to_details" do
+    it "raises NotImplementedError when called on class with no #to_details method" do
+      expect { edition_class_missing_implementation.new.to_details }.to raise_error(
+        NotImplementedError, "Subclasses must implement #to_details method"
+      )
+    end
+
+    it "can be implemented by subclasses" do
+      document = Block::Document.create!(sluggable_string: "other-type-block", block_type: "time_period")
+      edition = concrete_edition_class.new(
+        document: document,
+        title: "Other Type Title",
+      )
+      expect(edition.to_details).to eq({ "field_1" => "value 1" })
+    end
+  end
+end

--- a/spec/unit/app/models/block/edition_spec.rb
+++ b/spec/unit/app/models/block/edition_spec.rb
@@ -28,7 +28,41 @@ RSpec.describe Block::Edition, type: :model do
 
   describe "validations" do
     subject { concrete_edition_class.new(title: "Other Type Title") }
+
+    let(:document) { Block::Document.create!(sluggable_string: "test-block", block_type: "time_period") }
+
     it { is_expected.to validate_presence_of(:title) }
+
+    describe "title alphanumeric validation" do
+      it "is valid when title contains letters" do
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:)
+        expect(edition).to be_valid
+      end
+
+      it "is valid when title contains numbers" do
+        edition = concrete_edition_class.new(title: "2024", lead_organisation_id: SecureRandom.uuid, document:)
+        expect(edition).to be_valid
+      end
+
+      it "is invalid when title contains only special characters" do
+        edition = concrete_edition_class.new(title: "---", lead_organisation_id: SecureRandom.uuid, document:)
+        edition.valid?
+        expect(edition.errors[:title]).to include("must contain at least one letter or number")
+      end
+    end
+
+    describe "lead_organisation_id presence validation" do
+      it "is invalid when lead_organisation_id is blank" do
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: nil, document:)
+        edition.valid?
+        expect(edition.errors[:lead_organisation_id]).to include("cannot be blank")
+      end
+
+      it "is valid when lead_organisation_id is present" do
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:)
+        expect(edition).to be_valid
+      end
+    end
   end
 
   describe "#to_details" do

--- a/spec/unit/app/models/block/time_period_date_range_spec.rb
+++ b/spec/unit/app/models/block/time_period_date_range_spec.rb
@@ -13,6 +13,28 @@ RSpec.describe Block::TimePeriodDateRange, type: :model do
       it { is_expected.to validate_presence_of(:end) }
     end
 
+    describe "invalid date validation" do
+      it "is invalid when start date has invalid month" do
+        date_range = described_class.new(edition: edition)
+        # Simulate multiparameter assignment with invalid month (23)
+        date_range.start = { 1 => 2025, 2 => 23, 3 => 6, 4 => 0, 5 => 0 }
+        date_range.end = Time.zone.parse("2026-04-05 23:59")
+
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:start]).to include("Start date is not a valid date")
+      end
+
+      it "is invalid when end date has invalid day" do
+        date_range = described_class.new(edition: edition)
+        date_range.start = Time.zone.parse("2025-04-06 00:00")
+        # Simulate multiparameter assignment with invalid day (32)
+        date_range.end = { 1 => 2025, 2 => 4, 3 => 32, 4 => 23, 5 => 59 }
+
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:end]).to include("End date is not a valid date")
+      end
+    end
+
     describe "#end_date_after_start_date" do
       it "is invalid when end is before start" do
         date_range = described_class.new(

--- a/spec/unit/app/models/block/time_period_date_range_spec.rb
+++ b/spec/unit/app/models/block/time_period_date_range_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe Block::TimePeriodDateRange, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:edition).class_name("Block::TimePeriodEdition") }
+  end
+
+  describe "validations" do
+    let(:edition) { create(:block_time_period_edition) }
+
+    describe "presence validations" do
+      subject { described_class.new(edition: edition, start: Time.zone.parse("2025-01-01 00:00"), end: Time.zone.parse("3333-04-05 12:34")) }
+
+      it { is_expected.to validate_presence_of(:start) }
+      it { is_expected.to validate_presence_of(:end) }
+    end
+
+    describe "#end_date_after_start_date" do
+      it "is invalid when end is before start" do
+        date_range = described_class.new(
+          edition: edition,
+          start: Time.zone.parse("2025-04-06 00:00"),
+          end: Time.zone.parse("2025-04-05 23:59"),
+        )
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:end]).to include("must be after start date")
+      end
+
+      it "is invalid when end equals start" do
+        same_time = Time.zone.parse("2025-04-06 00:00")
+        date_range = described_class.new(
+          edition: edition,
+          start: same_time,
+          end: same_time,
+        )
+        expect(date_range).not_to be_valid
+        expect(date_range.errors[:end]).to include("must be after start date")
+      end
+
+      it "is valid when end is after start" do
+        date_range = described_class.new(
+          edition: edition,
+          start: Time.zone.parse("2025-04-06 00:00"),
+          end: Time.zone.parse("2026-04-05 23:59"),
+        )
+        expect(date_range).to be_valid
+      end
+    end
+  end
+
+  describe "#to_details" do
+    it "returns a hash with formatted start and end datetime" do
+      date_range = described_class.new(
+        start: Time.zone.parse("2025-04-06 00:00"),
+        end: Time.zone.parse("2026-04-05 23:59"),
+      )
+
+      expect(date_range.to_details).to eq({
+        "start" => "2025-04-06 00:00:00.00000000 +0100 ",
+        "end" => "2026-04-05 23:59:00.00000000 +0100",
+      })
+    end
+  end
+end

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -24,4 +24,25 @@ RSpec.describe Block::TimePeriodEdition, type: :model do
       expect(edition.errors[:title]).to include("cannot be blank")
     end
   end
+
+  describe "associations" do
+    it { is_expected.to have_one(:date_range).class_name("Block::TimePeriodDateRange").dependent(:destroy) }
+  end
+
+  describe "nested attributes" do
+    it "accepts nested attributes for date_range" do
+      edition = create(:block_time_period_edition)
+
+      edition.update!(
+        date_range_attributes: {
+          start: Time.zone.parse("2025-04-06 00:00"),
+          end: Time.zone.parse("2026-04-05 23:59"),
+        },
+      )
+
+      expect(edition.date_range).to be_present
+      expect(edition.date_range.start).to eq(Time.zone.parse("2025-04-06 00:00"))
+      expect(edition.date_range.end).to eq(Time.zone.parse("2026-04-05 23:59"))
+    end
+  end
 end

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Block::TimePeriodEdition, type: :model do
+  describe "inheritance" do
+    it "inherits from Block::Edition" do
+      expect(described_class.superclass).to eq(Block::Edition)
+    end
+
+    it "uses STI with correct type value" do
+      document = Block::Document.create!(sluggable_string: "test-block", block_type: "time_period")
+      edition = described_class.create!(
+        document: document,
+        title: "Test Time Period",
+        lead_organisation_id: SecureRandom.uuid,
+      )
+
+      expect(edition.type).to eq("Block::TimePeriodEdition")
+      expect(Block::Edition.find(edition.id)).to be_a(Block::TimePeriodEdition)
+    end
+  end
+
+  describe "validations" do
+    it "inherits title presence validation from Block::Edition" do
+      edition = described_class.new(title: nil, lead_organisation_id: SecureRandom.uuid)
+      expect(edition).not_to be_valid
+      expect(edition.errors[:title]).to include("cannot be blank")
+    end
+  end
+end

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -45,4 +45,47 @@ RSpec.describe Block::TimePeriodEdition, type: :model do
       expect(edition.date_range.end).to eq(Time.zone.parse("2026-04-05 23:59"))
     end
   end
+
+  describe "#to_details" do
+    it "returns hash with description and date_range to_details" do
+      date_range = build(:block_time_period_date_range,
+                         start: Time.zone.parse("2025-04-06 00:00"),
+                         end: Time.zone.parse("2026-04-05 23:59"))
+      edition = build(:block_time_period_edition,
+                      description: "Tax year 2025/26",
+                      date_range: date_range)
+
+      expect(edition.to_details).to eq({
+        "description" => "Tax year 2025/26",
+        "date_range" => {
+          "start" => "2025-04-06 00:00:00.000000000 +0100",
+          "end" => "2026-04-05 23:59:00.000000000 +0100",
+        },
+      })
+    end
+
+    it "returns hash with only description when date_range is nil" do
+      edition = build(:block_time_period_edition, description: "Tax year 2025/26")
+
+      expect(edition.to_details).to eq({
+        "description" => "Tax year 2025/26",
+      })
+    end
+
+    it "returns hash with only date_range when description is nil" do
+      date_range = build(:block_time_period_date_range,
+                         start: Time.zone.parse("2025-04-06 00:00"),
+                         end: Time.zone.parse("2026-04-05 23:59"))
+      edition = build(:block_time_period_edition,
+                      description: nil,
+                      date_range: date_range)
+
+      expect(edition.to_details).to eq({
+        "date_range" => {
+          "start" => "2025-04-06 00:00:00.000000000 +0100",
+          "end" => "2026-04-05 23:59:00.000000000 +0100",
+        },
+      })
+    end
+  end
 end


### PR DESCRIPTION
# Description

Includes the first pass at the models for the ActiveRecord refactoring, including:

- Block::Document
- Block::Edition
- Block::TimePeriodEdition
- Block::TimePeriodDateRange

Note: This doesn't yet provide any way of interacting with these models. Follow-on work will need to be done to include the forms, controllers, etc that will allow interactions with these models. This is merely a base layer to build on. As this is fairly foundational work in this process I think it's important to split this out on its own to ensure we're all happy with it before we move on to the next phase.

Based very heavily on the work by @edavey on https://github.com/alphagov/content-block-manager/pull/553 with only minor tweaks and relating to the ADR in #772 .

