### PR TITLE
Use embed codes in initial contents of 'picker' demo

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,38 @@
 class PagesController < ApplicationController
   def accessibility_statement; end
 
-  def content_block_picker_demo; end
+  def content_block_picker_demo
+    block_picker_demo_initial_content
+  end
+
+private
+
+  def block_picker_demo_initial_content
+    @block_picker_demo_initial_content = if ENV["GOVUK_ENVIRONMENT"] == "integration"
+                                           initial_content_with_integration_embed_codes
+                                         else
+                                           initial_content_without_embed_codes
+                                         end
+  end
+
+  def initial_content_with_integration_embed_codes
+    <<~MARKUP
+      The full rate of new State Pension is {{embed:content_block_pension:new-state-pension/rates/full-new-state-pension-amount/amount}} a week.
+
+      ### Contact us
+      {{embed:content_block_contact:feedback}}
+    MARKUP
+  end
+
+  def initial_content_without_embed_codes
+    <<~MARKUP
+      The full rate of new State Pension is £241.30 a week.
+
+      ### Contact us
+      Email: general.enquiries@example.gov.uk
+      We will aim to respond to your query within 2 business days.
+
+      Phone: 020 3738 6000
+    MARKUP
+  end
 end

--- a/app/views/pages/content_block_picker_demo.html.erb
+++ b/app/views/pages/content_block_picker_demo.html.erb
@@ -37,8 +37,7 @@
         rows="12"
         class="my-cbp govuk-textarea"
         data-module="content-block-highlight"
-        data-cbp-insert-block-button="insert-content-block-button">In alignment with our overarching strategic frameworks, we are proactively initiating a comprehensive, cross-functional paradigm shift designed to optimize systemic efficiencies across all vertical operational modalities. By shifting the critical path toward multi-tiered stakeholder integration, the department will effectively incentivize synergistic outcomes that transcend legacy infrastructural silos. Our primary objective remains the holistic recalibration of granular deliverables to maximize scalable output while minimizing mitigating risks within the institutional ecosystem.
-      </textarea>
+        data-cbp-insert-block-button="insert-content-block-button"><%= @block_picker_demo_initial_content %></textarea>
     </section>
   </div>
 </div>


### PR DESCRIPTION
By using some realistic copy which includes embed codes which are in use
in the integration environment, our users of the picker demo will be
immediately able to:

- see the highlighting of embed codes in action
- mouseover an embed code to view its rendered HTML

At present if the API responds with a 404 because we've tried to fetch
the rendered HTML for a embed code which can't be found, the picker throws
an error. Our cucumber specs currently specify that no JS errors are
encountered when the picker is loaded so perhaps this is suggesting
that an error is excessive for what's likely to be a routine occurrence?
-- when dealing with a free text textare perhaps it would be appropriate
to log a warning only on the client side?

For now we provide 2 sets of more realistic copy:

- with actual embed codes which work for the integration env
- with some realistic new state pension content in other envs

<img width="954" height="792" alt="real_embed_code" src="https://github.com/user-attachments/assets/6e55a7b0-2761-4614-ae4d-041e419de206" />
