### PR TITLE
(CR-62) Create TimePeriodEdition

### DIFF
--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -1,6 +1,9 @@
 module Block
   class TimePeriodEditionsController < BlocksController
-    def new; end
+    def new
+      @edition = Block::TimePeriodEdition.new
+      @edition.build_document(block_type:)
+    end
 
     def create; end
 

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -1,0 +1,9 @@
+module Block
+  class TimePeriodEditionsController < BlocksController
+    def new; end
+
+    def create; end
+
+    def show; end
+  end
+end

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -8,10 +8,13 @@ module Block
     def create
       @edition = Block::TimePeriodEdition.new(edition_params)
       @edition.build_document(block_type:)
-      @edition.save!
 
-      redirect_to block_time_period_editions_path,
-                  notice: I18n.t("block/time_period_edition.create.success")
+      if @edition.save
+        redirect_to block_time_period_edition_path(@edition.id),
+                    notice: I18n.t("block/time_period_edition.create.success")
+      else
+        render :new, status: :unprocessable_content
+      end
     end
 
     def show; end

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -5,7 +5,14 @@ module Block
       @edition.build_document(block_type:)
     end
 
-    def create; end
+    def create
+      @edition = Block::TimePeriodEdition.new(edition_params)
+      @edition.build_document(block_type:)
+      @edition.save!
+
+      redirect_to block_time_period_editions_path,
+                  notice: I18n.t("block/time_period_edition.create.success")
+    end
 
     def show; end
 

--- a/app/controllers/block/time_period_editions_controller.rb
+++ b/app/controllers/block/time_period_editions_controller.rb
@@ -5,5 +5,11 @@ module Block
     def create; end
 
     def show; end
+
+  private
+
+    def block_type
+      Block::Document.block_types[:time_period]
+    end
   end
 end

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -1,0 +1,10 @@
+class BlocksController < ApplicationController
+  def edition_params
+    params.require("edition").permit(
+      :description,
+      :lead_organisation_id,
+      :instructions_to_publishers,
+      :title,
+    ).merge(creator: current_user)
+  end
+end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -33,6 +33,10 @@ module Block
       "{{embed:content_block_#{block_type}:#{content_id_alias}/#{field_path}}}"
     end
 
+    def is_new_block?
+      editions.count == 1
+    end
+
   private
 
     def generate_content_id

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -19,6 +19,8 @@ module Block
     before_validation :generate_content_id, on: :create
     after_validation :set_content_id_alias_and_embed_code, on: :create
 
+    enum :block_type, { time_period: "time_period" }
+
     def title
       editions.order(created_at: :desc).first&.title
     end

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -1,6 +1,7 @@
 module Block
   class Edition < ApplicationRecord
     include ::Edition::HasLeadOrganisation
+    include ::Edition::HasAuthors
 
     belongs_to :document, class_name: "Block::Document", foreign_key: :block_document_id, inverse_of: :editions
 

--- a/app/views/block/time_period_editions/new.html.erb
+++ b/app/views/block/time_period_editions/new.html.erb
@@ -1,6 +1,8 @@
 <% content_for :context, I18n.t("block/time_period_edition.new.context") %>
 <% content_for :title, I18n.t("block/time_period_edition.new.title") %>
 
+<% content_for :error_summary, render(Shared::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+
 <%= form_with(
   model: @edition,
   url: block_time_period_editions_path,
@@ -20,6 +22,7 @@
       hint: I18n.t("edition.hints.#{@edition.document.block_type}.title", default: nil),
       name: "edition[title]",
       value: @edition.title,
+      error_items: errors_for(@edition.errors, :title),
       rows: 1,
     },
     maxlength: 65,
@@ -41,6 +44,7 @@
   <%= render "govuk_publishing_components/components/select_with_search", {
     id: "edition_lead_organisation_id",
     name: "edition[lead_organisation_id]",
+    error_items: errors_for(@edition.errors, :lead_organisation_id),
     hint: I18n.t("edition.hints.not_displayed"),
     include_blank: true,
     label: I18n.t("edition.labels.lead_organisation"),
@@ -55,6 +59,7 @@
     hint: t("edition.hints.instructions_to_publishers_html"),
     textarea_id: "edition_instructions_to_publishers",
     value: @edition.instructions_to_publishers,
+    error_items: errors_for(@edition.errors, :instructions_to_publishers),
     } %>
 
   <div class="govuk-button-group govuk-!-margin-bottom-6">

--- a/app/views/block/time_period_editions/new.html.erb
+++ b/app/views/block/time_period_editions/new.html.erb
@@ -1,0 +1,67 @@
+<% content_for :context, I18n.t("block/time_period_edition.new.context") %>
+<% content_for :title, I18n.t("block/time_period_edition.new.title") %>
+
+<%= form_with(
+  model: @edition,
+  url: block_time_period_editions_path,
+  method: :post,
+  ) do |f| %>
+
+  <p class="govuk-body">
+    <%= I18n.t("edition.new.general_field_notice") %>
+  </p>
+
+  <%= render "govuk_publishing_components/components/character_count", {
+    id: "edition_title",
+    textarea: {
+      label: {
+        text: label_for_title(@edition.document.block_type),
+      },
+      hint: I18n.t("edition.hints.#{@edition.document.block_type}.title", default: nil),
+      name: "edition[title]",
+      value: @edition.title,
+      rows: 1,
+    },
+    maxlength: 65,
+    } %>
+
+  <div class="app-c-content-block-manager-textarea-component">
+    <%= render "components/govspeak_editor", {
+      name: "edition[description]",
+      id: "edition_description",
+      label: { text: I18n.t("edition.labels.description") },
+      value: @edition.description,
+      error_items: errors_for(@edition.errors, :description),
+      hint_id: "edition_description_hint",
+      rows: 5,
+      character_limit: 165,
+      } %>
+  </div>
+
+  <%= render "govuk_publishing_components/components/select_with_search", {
+    id: "edition_lead_organisation_id",
+    name: "edition[lead_organisation_id]",
+    hint: I18n.t("edition.hints.not_displayed"),
+    include_blank: true,
+    label: I18n.t("edition.labels.lead_organisation"),
+    options: taggable_organisations_container([@edition.lead_organisation_id]),
+    } %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: I18n.t("edition.labels.instructions_to_publishers"),
+    },
+    name: "edition[instructions_to_publishers]",
+    hint: t("edition.hints.instructions_to_publishers_html"),
+    textarea_id: "edition_instructions_to_publishers",
+    value: @edition.instructions_to_publishers,
+    } %>
+
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= render "govuk_publishing_components/components/button", {
+      text: I18n.t("buttons.save_and_continue"),
+      type: "submit",
+      } %>
+  </div>
+
+<% end %>

--- a/app/views/block/time_period_editions/new.html.erb
+++ b/app/views/block/time_period_editions/new.html.erb
@@ -7,6 +7,7 @@
   model: @edition,
   url: block_time_period_editions_path,
   method: :post,
+  data: data_attributes_for_forms_with_text_fields(edition: @edition, block_type: @edition.document.block_type),
   ) do |f| %>
 
   <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -439,3 +439,5 @@ en:
     new:
       title: "Create time period"
       context: "Create content block"
+    create:
+      success: "Time period edition was successfully created."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,7 @@ en:
         start: Start date and time
         end: End date and time
     labels:
+      description: Description (optional)
       lead_organisation: Lead organisation
       instructions_to_publishers:
         Instructions to publishers (optional)
@@ -434,4 +435,7 @@ en:
       hour: Hour
       minute: Minute
 
-
+  block/time_period_edition:
+    new:
+      title: "Create time period"
+      context: "Create content block"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,11 @@ Rails.application.routes.draw do
     put "schedule", to: "documents/schedule#update", as: :update_schedule
     patch "schedule", to: "documents/schedule#update"
   end
+
+  namespace :block do
+    resources :time_period_editions, only: %i[new create show]
+  end
+
   resources :editions, only: %i[new create destroy], path_names: { new: ":block_type/new" } do
     member do
       get :preview, to: "editions#preview"

--- a/features/block/time_period/create_block.feature
+++ b/features/block/time_period/create_block.feature
@@ -1,0 +1,19 @@
+Feature: Create Time Period Edition
+  - So that I can publish a Time Period block
+  - As an editor
+  - I want to draft a Time Period Edition
+
+  Background:
+    Given I am logged in
+    And the organisation "Ministry of Example" exists
+    And I am viewing the form to create a new Time Period Edition
+
+  Scenario: Editor can create a new Time Period Edition
+    When I fill the Time Period Edition details correctly
+    And I save and continue
+    Then I see that the Edition was created successfully
+
+  Scenario: Editor is informed when creating a new Time Period Edition incorrectly
+    When I fill the Time Period Edition details incorrectly
+    And I save and continue
+    Then I see which Time Period Edition errors I need to correct

--- a/features/step_definitions/block/edition_steps.rb
+++ b/features/step_definitions/block/edition_steps.rb
@@ -1,0 +1,37 @@
+When("I am viewing the form to create a new Time Period Edition") do
+  visit new_block_time_period_edition_path
+end
+
+When("I fill the Time Period Edition details correctly") do
+  fill_in_edition_details(
+    title: "Test Time Period Edition",
+    description: "This is a test time period edition.",
+    lead_organisation: "Ministry of Example",
+    instructions: "Please review and publish.",
+  )
+end
+
+When("I fill the Time Period Edition details incorrectly") do
+  fill_in_edition_details(
+    title: "",
+    description: "This is a test time period edition.",
+    lead_organisation: "",
+    instructions: "Please review and publish.",
+  )
+end
+
+Then("I see that the Edition was created successfully") do
+  expect(page).to have_content(I18n.t("block/time_period_edition.create.success"))
+end
+
+Then("I see which Time Period Edition errors I need to correct") do
+  expect(page).to have_content("Title cannot be blank")
+  expect(page).to have_content("Lead organisation cannot be blank")
+end
+
+def fill_in_edition_details(title:, description:, lead_organisation:, instructions:)
+  fill_in "edition[title]", with: title
+  fill_in "Description", with: description
+  select lead_organisation, from: "Lead organisation"
+  fill_in "Instructions to publishers", with: instructions
+end

--- a/spec/controllers/blocks_controller_spec.rb
+++ b/spec/controllers/blocks_controller_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe BlocksController, type: :controller do
+  describe "#edition_params" do
+    let(:user) { create(:user) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    context "when passed attributes" do
+      let(:raw_params) do
+        {
+          edition: {
+            lead_organisation_id: "123",
+            instructions_to_publishers: "Some instructions",
+            title: "A title",
+            unpermitted_field: "should be filtered out",
+          },
+        }
+      end
+
+      before do
+        controller.params = ActionController::Parameters.new(raw_params)
+      end
+
+      it "permits the expected top-level attributes" do
+        result = controller.send(:edition_params)
+
+        expect(result[:lead_organisation_id]).to eq("123")
+        expect(result[:instructions_to_publishers]).to eq("Some instructions")
+        expect(result[:title]).to eq("A title")
+      end
+
+      it "filters out unpermitted attributes" do
+        result = controller.send(:edition_params)
+
+        expect(result).not_to have_key(:unpermitted_field)
+      end
+
+      it "merges in the current_user as creator" do
+        result = controller.send(:edition_params)
+
+        expect(result[:creator]).to eq(user)
+      end
+
+      it "returns permitted params" do
+        result = controller.send(:edition_params)
+
+        expect(result.permitted?).to be true
+      end
+    end
+
+    context "when edition key is missing" do
+      before do
+        controller.params = ActionController::Parameters.new({})
+      end
+
+      it "raises ActionController::ParameterMissing" do
+        expect { controller.send(:edition_params) }
+          .to raise_error(ActionController::ParameterMissing,
+                          "param is missing or the value is empty or invalid: edition")
+      end
+    end
+  end
+end

--- a/spec/factories/block/time_period_edition.rb
+++ b/spec/factories/block/time_period_edition.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     sequence(:title) { |n| "Time Period #{n}" }
     description { "A time period description" }
     lead_organisation_id { SecureRandom.uuid }
+    creator { association :user }
   end
 end

--- a/spec/requests/block/time_period_editions_spec.rb
+++ b/spec/requests/block/time_period_editions_spec.rb
@@ -14,15 +14,44 @@ RSpec.describe "Block time period editions", type: :request do
   end
 
   describe "GET /block/time_period_editions/new" do
-    before do
-      allow(Organisation).to receive(:all).and_return([])
-    end
+    describe "when rendering the new template" do
+      before do
+        allow(Organisation).to receive(:all).and_return([])
 
-    it "renders the new edition page" do
-      get new_block_time_period_edition_path
+        get new_block_time_period_edition_path
+      end
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template("block/time_period_editions/new")
+      it "renders the correct page successfully" do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("block/time_period_editions/new")
+      end
+
+      it "contains the correct form with the required fields" do
+        expect(page).to have_css("form[action='#{block_time_period_editions_path}']") do |form|
+          expect(form).to have_field("edition[title]")
+          expect(form).to have_field("edition[description]")
+          expect(form).to have_field("edition[lead_organisation_id]")
+          expect(form).to have_field("edition[instructions_to_publishers]")
+          expect(form).to have_button("Save and continue")
+        end
+      end
+
+      it "contains character-limited fields with the correct character limits" do
+        expect(page).to have_css(".govuk-character-count[data-module='govuk-character-count'][data-maxlength='65']")
+        expect(page).to have_css(".govuk-character-count__message", text: "You can enter up to 65 characters")
+
+        expect(page).to have_css(".govuk-character-count[data-module='govuk-character-count'][data-maxlength='165']")
+        expect(page).to have_css(".govuk-character-count__message", text: "You can enter up to 165 characters")
+      end
+
+      it "initialises a time period edition with a time period document" do
+        edition = assigns(:edition)
+
+        expect(edition).to be_a(Block::TimePeriodEdition)
+        expect(edition).to be_new_record
+        expect(edition.document).to be_new_record
+        expect(edition.document.block_type).to eq("time_period")
+      end
     end
   end
 end

--- a/spec/requests/block/time_period_editions_spec.rb
+++ b/spec/requests/block/time_period_editions_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Block time period editions", type: :request do
+  before do
+    logout
+    login_as(create(:user))
+  end
+
+  describe "GET /block/time_period_edition/:id" do
+    it "renders the time period edition 'show' page" do
+      get block_time_period_edition_path(0)
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template("block/time_period_editions/show")
+    end
+  end
+
+  describe "GET /block/time_period_editions/new" do
+    before do
+      allow(Organisation).to receive(:all).and_return([])
+    end
+
+    it "renders the new edition page" do
+      get new_block_time_period_edition_path
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template("block/time_period_editions/new")
+    end
+  end
+end

--- a/spec/requests/block/time_period_editions_spec.rb
+++ b/spec/requests/block/time_period_editions_spec.rb
@@ -54,4 +54,52 @@ RSpec.describe "Block time period editions", type: :request do
       end
     end
   end
+
+  describe "POST /block/time_period_edition/:id" do
+    before do
+      allow(Organisation).to receive(:all).and_return([])
+    end
+
+    context "with valid parameters" do
+      let(:valid_params) do
+        {
+          edition: {
+            title: "Test Time Period Edition",
+            description: "This is a test time period edition.",
+            lead_organisation_id: SecureRandom.uuid,
+            instructions_to_publishers: "Please follow the instructions.",
+          },
+        }
+      end
+
+      it "creates a new time period edition and redirects to the time period edition page with a success message" do
+        expect {
+          post block_time_period_editions_path, params: valid_params
+        }.to change(Block::TimePeriodEdition, :count).by(1)
+
+        expect(response).to redirect_to(block_time_period_edition_path(Block::TimePeriodEdition.last.id))
+        follow_redirect!
+        expect(response.body).to include(I18n.t("block/time_period_edition.create.success"))
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_params) do
+        {
+          edition: {
+            title: "", # Invalid because title is required
+            lead_organisation_id: nil, # Invalid because lead_organisation_id is required
+          },
+        }
+      end
+
+      it "does not create a new time period edition and redirects to index" do
+        expect {
+          post block_time_period_editions_path, params: invalid_params
+        }.not_to change(Block::TimePeriodEdition, :count)
+
+        expect(response).not_to redirect_to(block_time_period_editions_path)
+      end
+    end
+  end
 end

--- a/spec/requests/block/time_period_editions_spec.rb
+++ b/spec/requests/block/time_period_editions_spec.rb
@@ -93,12 +93,19 @@ RSpec.describe "Block time period editions", type: :request do
         }
       end
 
-      it "does not create a new time period edition and redirects to index" do
+      it "does not create a new time period edition and re-renders the form with errors" do
         expect {
           post block_time_period_editions_path, params: invalid_params
         }.not_to change(Block::TimePeriodEdition, :count)
 
-        expect(response).not_to redirect_to(block_time_period_editions_path)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to render_template("block/time_period_editions/new")
+
+        expect(page).to have_css(".gem-c-error-summary__list-item", text: "Title cannot be blank")
+        expect(page).to have_css(".gem-c-error-summary__list-item", text: "Lead organisation cannot be blank")
+
+        expect(page).to have_css(".govuk-error-message", text: "Title cannot be blank")
+        expect(page).to have_css(".govuk-error-message", text: "Lead organisation cannot be blank")
       end
     end
   end

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -115,4 +115,24 @@ RSpec.describe Block::Document, type: :model do
       expect(document.title).to be_nil
     end
   end
+
+  describe "#is_new_block?" do
+    it "returns true if there is only one edition" do
+      document = create(:block_document, block_type: "time_period")
+      create(:block_time_period_edition, document: document, creator:)
+
+      expect(document.is_new_block?).to be true
+    end
+
+    it "returns false if there are multiple editions" do
+      document = create(:block_document, block_type: "time_period")
+
+      expect(document.is_new_block?).to be false
+
+      create(:block_time_period_edition, document: document, creator:)
+      create(:block_time_period_edition, document: document, creator:)
+
+      expect(document.is_new_block?).to be false
+    end
+  end
 end

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Block::Document, type: :model do
     end
   end
 
+  let(:creator) { create(:user) }
+
   describe "associations" do
     describe "#time_period_editions" do
       it "builds a TimePeriodEdition with the correct type" do
@@ -23,8 +25,8 @@ RSpec.describe Block::Document, type: :model do
 
       it "only returns TimePeriodEdition instances" do
         document = create(:block_document, block_type: "time_period")
-        time_period = create(:block_time_period_edition, document: document)
-        other = block_edition_with_details.new(document: document, title: "Foo Edition").save!
+        time_period = create(:block_time_period_edition, document: document, creator:)
+        other = block_edition_with_details.new(document: document, title: "Foo Edition", creator:).save!
 
         expect(document.editions.count).to eq(2)
         expect(document.time_period_editions.count).to eq(1)
@@ -101,8 +103,8 @@ RSpec.describe Block::Document, type: :model do
   describe "#title" do
     it "returns the title from the most recent edition" do
       document = create(:block_document, block_type: "time_period")
-      create(:block_time_period_edition, document: document, title: "First Edition", created_at: 1.day.ago)
-      create(:block_time_period_edition, document: document, title: "Latest Edition", created_at: Time.current)
+      create(:block_time_period_edition, document: document, title: "First Edition", created_at: 1.day.ago, creator:)
+      create(:block_time_period_edition, document: document, title: "Latest Edition", created_at: Time.current, creator:)
 
       expect(document.title).to eq("Latest Edition")
     end

--- a/spec/unit/app/models/block/edition_spec.rb
+++ b/spec/unit/app/models/block/edition_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Block::Edition, type: :model do
     end
   end
 
+  let(:creator) { create(:user) }
+
   describe "associations" do
     subject { concrete_edition_class.new(title: "Other Type Title") }
     it { is_expected.to belong_to(:document).class_name("Block::Document") }
@@ -35,17 +37,17 @@ RSpec.describe Block::Edition, type: :model do
 
     describe "title alphanumeric validation" do
       it "is valid when title contains letters" do
-        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:)
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:, creator:)
         expect(edition).to be_valid
       end
 
       it "is valid when title contains numbers" do
-        edition = concrete_edition_class.new(title: "2024", lead_organisation_id: SecureRandom.uuid, document:)
+        edition = concrete_edition_class.new(title: "2024", lead_organisation_id: SecureRandom.uuid, document:, creator:)
         expect(edition).to be_valid
       end
 
       it "is invalid when title contains only special characters" do
-        edition = concrete_edition_class.new(title: "---", lead_organisation_id: SecureRandom.uuid, document:)
+        edition = concrete_edition_class.new(title: "---", lead_organisation_id: SecureRandom.uuid, document:, creator:)
         edition.valid?
         expect(edition.errors[:title]).to include("must contain at least one letter or number")
       end
@@ -53,13 +55,13 @@ RSpec.describe Block::Edition, type: :model do
 
     describe "lead_organisation_id presence validation" do
       it "is invalid when lead_organisation_id is blank" do
-        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: nil, document:)
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: nil, document:, creator:)
         edition.valid?
         expect(edition.errors[:lead_organisation_id]).to include("cannot be blank")
       end
 
       it "is valid when lead_organisation_id is present" do
-        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:)
+        edition = concrete_edition_class.new(title: "Valid Title", lead_organisation_id: SecureRandom.uuid, document:, creator:)
         expect(edition).to be_valid
       end
     end
@@ -77,6 +79,7 @@ RSpec.describe Block::Edition, type: :model do
       edition = concrete_edition_class.new(
         document: document,
         title: "Other Type Title",
+        creator:,
       )
       expect(edition.to_details).to eq({ "field_1" => "value 1" })
     end

--- a/spec/unit/app/models/block/time_period_edition_spec.rb
+++ b/spec/unit/app/models/block/time_period_edition_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Block::TimePeriodEdition, type: :model do
+  let(:creator) { create(:user) }
+
   describe "inheritance" do
     it "inherits from Block::Edition" do
       expect(described_class.superclass).to eq(Block::Edition)
@@ -10,6 +12,7 @@ RSpec.describe Block::TimePeriodEdition, type: :model do
         document: document,
         title: "Test Time Period",
         lead_organisation_id: SecureRandom.uuid,
+        creator:,
       )
 
       expect(edition.type).to eq("Block::TimePeriodEdition")

--- a/spec/views/block/time_period_edition_spec.rb
+++ b/spec/views/block/time_period_edition_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "block/time_period_editions/new", type: :view do
+  describe "when rendering the new template" do
+    before do
+      assign(:edition, create(:block_time_period_edition))
+
+      allow(Organisation).to receive(:all).and_return([])
+    end
+
+    it "should attach the required data attributes to enable the 'unused changes prompt' for the user" do
+      render
+
+      expect(rendered).to have_css('form[data-module~="unsaved-changes-prompt"]')
+    end
+
+    it "should attach the required data attributes to enable the 'ga4 form tracking' for the user" do
+      render
+
+      expect(rendered).to have_css('form[data-ga4-action="create"]')
+      expect(rendered).to have_css('form[data-module~="ga4-form-tracker"]')
+      expect(rendered).to have_css('form[data-ga4-tool-name="time_period"]')
+    end
+  end
+end


### PR DESCRIPTION
# Description

Allow users to create a new-style TimePeriodEdition.

Create standard form and fields to allow creation of a new time period edition, retaining much of the original functionality from the main app, including edition creation, GA4 attributes, JS modules, character count fields etc. Reuses existing Authoring functionality too.

Does not yet include the ability to Edit the edition or to navigate 'back' from this page, but this can follow shortly.

# Screenshot

<img width="1309" height="1514" alt="Screenshot 2026-07-28 at 14 16 38" src="https://github.com/user-attachments/assets/8cbbcdab-e72f-4dc5-869a-104b83cd0e58" />

