### PR TITLE
Add an index page for viewing ActiveRecord documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ and running.
 To run all linters, run:
 
 ```bash
-bundle exec rake:lint
+bundle exec rake lint
 ```
 
 To run all linter with automatic formatting corrections, run:
 
 ```bash
-bundle exec rake:lint_autocorrect
+bundle exec rake lint_autocorrect
 ```
 
 ### API

--- a/app/components/document/index/v2/summary_card_component.html.erb
+++ b/app/components/document/index/v2/summary_card_component.html.erb
@@ -1,0 +1,5 @@
+<%= render "govuk_publishing_components/components/summary_card", {
+  title:,
+  rows:,
+  summary_card_actions:,
+} %>

--- a/app/components/document/index/v2/summary_card_component.rb
+++ b/app/components/document/index/v2/summary_card_component.rb
@@ -1,0 +1,55 @@
+class Document::Index::V2::SummaryCardComponent < ViewComponent::Base
+  def initialize(document:)
+    @document = document
+  end
+
+private
+
+  attr_reader :document
+
+  def rows
+    [
+      title_item,
+      description_item,
+      organisation_item,
+    ].compact
+  end
+
+  def title_item
+    {
+      key: helpers.label_for_title(document.block_type),
+      value: document.title,
+    }
+  end
+
+  def description_item
+    {
+      key: "Description",
+      value: edition.description,
+    }
+  end
+
+  def organisation_item
+    {
+      key: "Lead organisation",
+      value: edition.lead_organisation.name,
+    }
+  end
+
+  def title
+    document.title
+  end
+
+  def summary_card_actions
+    [
+      {
+        label: "View",
+        href: "",
+      },
+    ]
+  end
+
+  def edition
+    @edition = document.most_recent_edition
+  end
+end

--- a/app/controllers/block/documents_controller.rb
+++ b/app/controllers/block/documents_controller.rb
@@ -1,7 +1,7 @@
 module Block
   class DocumentsController < ApplicationController
     def index
-
+      @documents = Block::Document.by_most_recently_created_edition.page(1)
     end
   end
 end

--- a/app/controllers/block/documents_controller.rb
+++ b/app/controllers/block/documents_controller.rb
@@ -1,0 +1,7 @@
+module Block
+  class DocumentsController < ApplicationController
+    def index
+
+    end
+  end
+end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -26,6 +26,16 @@ module Block
 
     enum :block_type, { time_period: "time_period" }
 
+    scope :by_most_recently_created_edition, lambda {
+      latest_edition = Block::Edition
+        .select(:created_at)
+        .where("block_editions.block_document_id = block_documents.id")
+        .order(created_at: :desc)
+        .limit(1)
+
+      order(Arel.sql("(#{latest_edition.to_sql}) DESC NULLS LAST"))
+    }
+
     def title
       most_recent_edition&.title
     end

--- a/app/models/block/document.rb
+++ b/app/models/block/document.rb
@@ -16,13 +16,18 @@ module Block
              dependent: :destroy,
              inverse_of: :document
 
+    has_one :most_recent_edition,
+            -> { most_recent_first },
+            foreign_key: :block_document_id,
+            class_name: "Block::Edition"
+
     before_validation :generate_content_id, on: :create
     after_validation :set_content_id_alias_and_embed_code, on: :create
 
     enum :block_type, { time_period: "time_period" }
 
     def title
-      editions.order(created_at: :desc).first&.title
+      most_recent_edition&.title
     end
 
     def built_embed_code

--- a/app/models/block/edition.rb
+++ b/app/models/block/edition.rb
@@ -10,6 +10,8 @@ module Block
 
     before_validation :set_document_sluggable_string, on: :create
 
+    scope :most_recent_first, -> { order(created_at: :desc) }
+
     # Abstract method to be implemented by subclasses
     # Returns a hash representation of the edition's details
     def to_details

--- a/app/views/block/documents/index.html.erb
+++ b/app/views/block/documents/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Home" %>
+
+<div class="govuk-grid-row content-block-manager-header">
+  <div class="govuk-grid-column-one-half">
+    <h1 class="govuk-heading-xl content-block-manager-header--heading">
+      Content Block Manager - ActiveRecord Blocks
+    </h1>
+
+    <p class="govuk-body">Create, edit and use standardised content across GOV.UK</p>
+  </div>
+</div>

--- a/app/views/block/documents/index.html.erb
+++ b/app/views/block/documents/index.html.erb
@@ -9,3 +9,19 @@
     <p class="govuk-body">Create, edit and use standardised content across GOV.UK</p>
   </div>
 </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m"><%= pluralize(@documents.total_count, "result") %></h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <p class="govuk-body"><strong>Sorted by most recently updated</strong></p>
+    <% @documents.each_with_index do |document, index| %>
+      <div data-testid="homepage-item-<%= index %>">
+        <%= render Document::Index::V2::SummaryCardComponent.new(document:) %>
+      </div>
+    <% end %>
+
+    <%= paginate(@documents, theme: "govuk_paginator") %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
 
   namespace :block do
     resources :time_period_editions, only: %i[new create show]
+    resources :documents, only: [:index]
   end
 
   resources :editions, only: %i[new create destroy], path_names: { new: ":block_type/new" } do

--- a/features/block/view_content_blocks.feature
+++ b/features/block/view_content_blocks.feature
@@ -1,0 +1,13 @@
+Feature: Search for a content object
+  Background:
+    Given I am logged in
+    And the organisation "Department of Placeholder" exists
+    And the organisation "Ministry of Example" exists
+    And the following time period content blocks have been drafted:
+        | Time period name              | Description                             | Organisation              |
+        | British Summer Time           | The period of daylight savings          | Department of Placeholder |
+        | Student loan repayment period | The repayment period for a student loan | Ministry of Example       |
+
+Scenario: view all available content blocks
+    When I visit the blocks index page
+    Then I should see the details for all three available content blocks

--- a/features/step_definitions/block_creation_steps_v2.rb
+++ b/features/step_definitions/block_creation_steps_v2.rb
@@ -1,0 +1,23 @@
+Given("the following time period content blocks have been drafted:") do |table|
+  table.hashes.each do |row|
+    organisation = Organisation.all&.find { |org| org.name == row["Organisation"] }
+
+    document = Block::Document.new(block_type: "time_period")
+
+    Block::TimePeriodEdition.create!(
+      document: document,
+      title: row["Time period name"],
+      description: row["Description"],
+      lead_organisation_id: organisation.id,
+      creator: build(:user),
+    )
+  end
+end
+
+Then("I should see the details for all three available content blocks") do
+  Block::TimePeriodEdition.find_each do |edition|
+    expect(page).to have_content(edition.title)
+    expect(page).to have_content(edition.description)
+    expect(page).to have_content(edition.lead_organisation.name)
+  end
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -12,6 +12,10 @@ When("I revisit the edit page") do
   visit_edit_page
 end
 
+When("I visit the blocks index page") do
+  visit block_documents_path
+end
+
 Given("I am viewing the published edition") do
   edition = Document.last.editions.published.most_recent
   visit document_path(edition.document)

--- a/spec/components/document/index/v2/summary_card_component_spec.rb
+++ b/spec/components/document/index/v2/summary_card_component_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Document::Index::V2::SummaryCardComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:document) { build_stubbed(:block_document, block_type: "time_period") }
+  let(:organisation) { build(:organisation) }
+
+  let(:edition) do
+    build_stubbed(
+      :block_time_period_edition,
+      id: 123,
+      description: "some time period description",
+      lead_organisation_id: organisation.id,
+      updated_at: 1.day.ago,
+      document: document,
+    )
+  end
+
+  before do
+    expect(document).to receive(:most_recent_edition).at_least(:once).and_return(edition)
+    allow(Organisation).to receive(:all).and_return([organisation])
+  end
+
+  it "renders a content block as a summary card" do
+    render_inline(described_class.new(document:))
+
+    expect(page).to have_css ".govuk-summary-card__title", text: edition.title
+    expect(page).to have_css ".govuk-summary-card__action", count: 1
+    expect(page).to have_css ".govuk-summary-card__action .govuk-link[href='']"
+
+    expect(page).to have_css ".govuk-link", text: "View"
+
+    expect(page).to have_css ".govuk-summary-list__row", count: 3
+
+    expect(page).to have_summary_row.with_key("Time period name").with_value(edition.title)
+
+    expect(page).to have_summary_row.with_key("Description").with_value(edition.description)
+
+    expect(page).to have_summary_row.with_key("Lead organisation").with_value(edition.lead_organisation.name)
+  end
+end

--- a/spec/requests/block/documents_spec.rb
+++ b/spec/requests/block/documents_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe "Block documents", type: :request do
+  before do
+    logout
+    login_as(create(:user))
+  end
+
+  describe "GET /block/documents" do
+    let(:organisation) { build(:organisation) }
+
+    before do
+      allow(Organisation).to receive(:all).and_return([organisation])
+    end
+
+    it "renders the index page with listed block documents sorted by most recently created edition" do
+      document_with_older_edition = create(:block_document)
+      create(
+        :block_time_period_edition,
+        document: document_with_older_edition,
+        title: "Tax Year 2025",
+        lead_organisation_id: organisation.id,
+        created_at: 1.year.ago,
+      )
+
+      document_with_newer_edition = create(:block_document)
+      create(
+        :block_time_period_edition,
+        document: document_with_newer_edition,
+        title: "British Summer Time 2026",
+        lead_organisation_id: organisation.id,
+        created_at: 1.day.ago,
+      )
+
+      get block_documents_path
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template("block/documents/index")
+
+      expect(page).to have_css("[data-testid='homepage-item-0']", text: "British Summer Time 2026")
+      expect(page).to have_css("[data-testid='homepage-item-1']", text: "Tax Year 2025")
+    end
+  end
+end

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe Block::Document, type: :model do
     end
   end
 
+  describe ".by_most_recently_created_edition" do
+    it "orders documents so the document with the most recently created edition appears first" do
+      older_document_with_newer_edition = create(:block_document, created_at: 4.days.ago)
+      create(:block_time_period_edition, document: older_document_with_newer_edition, created_at: 4.days.ago)
+      create(:block_time_period_edition, document: older_document_with_newer_edition, created_at: 1.day.ago)
+
+      newer_document_with_older_edition = create(:block_document, created_at: 3.days.ago)
+      create(:block_time_period_edition, document: newer_document_with_older_edition, created_at: 3.days.ago)
+      create(:block_time_period_edition, document: newer_document_with_older_edition, created_at: 2.days.ago)
+
+      expect(described_class.by_most_recently_created_edition).to eq([older_document_with_newer_edition, newer_document_with_older_edition])
+    end
+  end
+
   describe "#built_embed_code" do
     it "returns the embed code format using content_id_alias" do
       document = described_class.new(

--- a/spec/unit/app/models/block/document_spec.rb
+++ b/spec/unit/app/models/block/document_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe Block::Document, type: :model do
         expect(document.time_period_editions).not_to include(other)
       end
     end
+
+    describe "#most_recent_edition" do
+      it "returns the most recently created edition" do
+        document = create(:block_document, block_type: "time_period")
+
+        _older_edition = create(:block_time_period_edition, document: document, created_at: 2.days.ago)
+        newer_edition = create(:block_time_period_edition, document: document, created_at: 1.day.ago)
+        _oldest_edition = create(:block_time_period_edition, document: document, created_at: 3.days.ago)
+
+        expect(document.most_recent_edition).to eq(newer_edition)
+      end
+
+      it "returns nil when there are no editions" do
+        document = create(:block_document, block_type: "time_period")
+
+        expect(document.most_recent_edition).to be_nil
+      end
+    end
   end
 
   describe "callbacks" do

--- a/spec/unit/app/models/block/edition_spec.rb
+++ b/spec/unit/app/models/block/edition_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Block::Edition, type: :model do
     it { is_expected.to belong_to(:document).class_name("Block::Document") }
   end
 
+  describe ".most_recent_first" do
+    it "orders records by created_at in descending order" do
+      older_edition = create(:block_time_period_edition, created_at: 2.days.ago)
+      newer_edition = create(:block_time_period_edition, created_at: 1.day.ago)
+
+      expect(described_class.most_recent_first).to eq([newer_edition, older_edition])
+    end
+  end
+
   describe "validations" do
     subject { concrete_edition_class.new(title: "Other Type Title") }
 


### PR DESCRIPTION
This PR adds a new index page for viewing refactored ActiveRecord documents. This is a copy of the existing index page for the JSON schema documents, albeit at this point it does not include filter functionality - that will come in a subsequent PR.

Rather than adding endless conditional statements to the existing summary card component so that it’s also compatible with the ActiveRecord document, I’ve created a ‘v2’ summary card component, which only serves ActiveRecord documents. This should make it much easier and cleaner to turn off the v1 implementation and move over entirely to v2, when the time comes.

<img width="716" height="797" alt="Screenshot 2026-07-29 at 15 36 04" src="https://github.com/user-attachments/assets/f5edb449-f225-4c66-81da-9ee0ed15847d" />
