### PR TITLE
Excludes e2e test objects from the API

### DIFF
--- a/app/models/document/hideable_from_search_index.rb
+++ b/app/models/document/hideable_from_search_index.rb
@@ -5,6 +5,16 @@ module Document::HideableFromSearchIndex
     before_create :set_testing_artefact
   end
 
+  class_methods do
+    def visible_in_search_index
+      Current.user&.is_e2e_user? ? all : where(testing_artefact: false)
+    end
+  end
+
+  def hidden_from_search_index?
+    testing_artefact? && !current_user_is_e2e_user?
+  end
+
 private
 
   def set_testing_artefact

--- a/app/public/lib/public/current.rb
+++ b/app/public/lib/public/current.rb
@@ -1,0 +1,5 @@
+module Public::Current
+  def self.user
+    ::Current.user
+  end
+end

--- a/app/public/models/content_block.rb
+++ b/app/public/models/content_block.rb
@@ -17,6 +17,8 @@ class ContentBlock
 
       base_embed_code = embed_code.gsub(/[\/#][^}]+/, "")
       document = Document.find_by(embed_code: base_embed_code)
+      return nil if document&.hidden_from_search_index?
+
       latest_published_edition = document&.latest_published_edition
       return nil unless latest_published_edition
 

--- a/app/public/queries/content_block/query.rb
+++ b/app/public/queries/content_block/query.rb
@@ -23,6 +23,7 @@ class ContentBlock
     def unpaginated_results
       Document.joins(:editions)
               .merge(Edition.most_recent_published_for_document)
+              .visible_in_search_index
               .extending(Scopes)
               .by_block_type(filters[:block_type])
               .by_lead_organisation_id(filters[:lead_organisation_id])

--- a/engines/api/app/controllers/api/blocks_controller.rb
+++ b/engines/api/app/controllers/api/blocks_controller.rb
@@ -6,12 +6,10 @@ class Api::BlocksController < Api::ApplicationController
 
   def render_block
     embed_code = params[:embed_code]
-    block = ContentBlock.from_embed_code(Rack::Utils.unescape_path(params[:embed_code].to_s))
-    if block
-      render html: block.render(embed_code)
-    else
-      not_found_page_error "Content block not found for embed code: #{embed_code}"
-    end
+    block = ContentBlock.from_embed_code(Rack::Utils.unescape_path(embed_code.to_s))
+    return not_found_page_error "Content block not found for embed code: #{embed_code}" if block.nil?
+
+    render html: block.render(embed_code)
   end
 
 private

--- a/engines/api/spec/requests/api_spec.rb
+++ b/engines/api/spec/requests/api_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "API" do
 
     before do
       allow(Organisation).to receive(:all).and_return(organisations)
+      allow(Current).to receive(:user).and_return(nil)
     end
 
     get "Search for content blocks" do
@@ -122,6 +123,40 @@ RSpec.describe "API" do
           expect(data["results"].first["title"]).to eq("first")
         end
       end
+
+      response "200", "excludes testing artefacts", document: false do
+        before do
+          testing_doc = create(:document)
+          testing_doc.update!(testing_artefact: true)
+          create(:edition, :published, document: testing_doc, lead_organisation_id: organisations.first.id, title: "Test Block")
+          regular_doc = create(:document, testing_artefact: false)
+          create(:edition, :published, document: regular_doc, lead_organisation_id: organisations.first.id, title: "Regular Block")
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["results"].size).to eq(1)
+          expect(data["results"].first["title"]).to eq("Regular Block")
+        end
+      end
+
+      response "200", "includes testing artefacts for e2e users", document: false do
+        before do
+          testing_doc = create(:document)
+          testing_doc.update!(testing_artefact: true)
+          create(:edition, :published, document: testing_doc, lead_organisation_id: organisations.first.id, title: "Test Block")
+          regular_doc = create(:document, testing_artefact: false)
+          create(:edition, :published, document: regular_doc, lead_organisation_id: organisations.first.id, title: "Regular Block")
+
+          mock_user = instance_double("User", is_e2e_user?: true)
+          allow(Current).to receive(:user).and_return(mock_user)
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["results"].size).to eq(2)
+        end
+      end
     end
   end
 
@@ -135,6 +170,10 @@ RSpec.describe "API" do
       produces "text/html", "application/json"
 
       parameter name: "embed_code", in: :path, type: :string, required: true, description: "The embed code to render. This can be a base embed code or one that targets a specific field or format."
+
+      before do
+        allow(Current).to receive(:user).and_return(nil)
+      end
 
       def normalise_html(html)
         fragment = Nokogiri::HTML.fragment(html)
@@ -327,6 +366,63 @@ RSpec.describe "API" do
         run_test! do |response|
           data = JSON.parse(response.body)
           expect(data["error"]).to be_present
+        end
+      end
+
+      response "404", "returns an error for testing artefacts", document: false do
+        before do
+          @document = create(
+            :document,
+            block_type: "pension",
+            sluggable_string: "test-pension",
+            content_id: "99999999-9999-9999-9999-999999999999",
+          )
+          @document.update!(testing_artefact: true)
+          create(
+            :edition,
+            :published,
+            title: "Test Pension",
+            lead_organisation_id: SecureRandom.uuid,
+            document: @document,
+          )
+        end
+
+        let(:embed_code) { CGI.escape(@document.embed_code) }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to eq({
+            "error" => "Content block not found for embed code: #{@document.embed_code}",
+          })
+        end
+      end
+
+      response "200", "can render testing artefacts for e2e users", document: false do
+        before do
+          @document = create(
+            :document,
+            block_type: "pension",
+            sluggable_string: "test-pension-e2e",
+            content_id: "88888888-8888-8888-8888-888888888888",
+          )
+          @document.update!(testing_artefact: true)
+          create(
+            :edition,
+            :published,
+            title: "Test Pension E2E",
+            lead_organisation_id: SecureRandom.uuid,
+            document: @document,
+          )
+
+          mock_user = instance_double("User", is_e2e_user?: true)
+          allow(Current).to receive(:user).and_return(mock_user)
+        end
+
+        let(:embed_code) { CGI.escape(@document.embed_code) }
+
+        run_test! do |response|
+          expect(response.content_type).to include("text/html")
+          expect(response.body).to include("Test Pension E2E")
         end
       end
     end


### PR DESCRIPTION
The application excludes e2e test ojects from searches. This ports that behavior to the API

Introduced shared visibility methods in HideableFromSearchIndex.

 - ContentBlock::Query now applies Document.visible_in_search_index for /blocks/search.
 - ContentBlock.from_embed_code now returns nil when a document is hidden from search index.
 - Api::BlocksController no longer has custom filter_testing_artefacts / testing_artefact_hidden logic.