### PR TITLE
Stop publishing blocks to Content Store

### DIFF
--- a/app/presenters/publishing_api/content_block_presenter.rb
+++ b/app/presenters/publishing_api/content_block_presenter.rb
@@ -14,12 +14,10 @@ module PublishingApi
         title: edition.title,
         instructions_to_publishers: edition.instructions_to_publishers,
         content_id_alias:,
-        base_path:,
         details: edition.details,
         links:,
         update_type:,
         change_note:,
-        routes:,
       }
     end
 
@@ -41,19 +39,6 @@ module PublishingApi
 
     def change_note
       edition.major_change ? edition.change_note : nil
-    end
-
-    def base_path
-      "/content-blocks/#{document_type}/#{content_id_alias}"
-    end
-
-    def routes
-      [
-        {
-          path: base_path,
-          type: "exact",
-        },
-      ]
     end
   end
 end

--- a/spec/unit/app/presenters/publishing_api/content_block_presenter_spec.rb
+++ b/spec/unit/app/presenters/publishing_api/content_block_presenter_spec.rb
@@ -31,19 +31,12 @@ RSpec.describe PublishingApi::ContentBlockPresenter do
         title:,
         instructions_to_publishers:,
         content_id_alias:,
-        base_path: "/content-blocks/#{document_type}/#{content_id_alias}",
         change_note:,
         details:,
         update_type: "major",
         links: {
           primary_publishing_organisation: [lead_organisation.id],
         },
-        routes: [
-          {
-            path: "/content-blocks/#{document_type}/#{content_id_alias}",
-            type: "exact",
-          },
-        ],
       })
     end
 


### PR DESCRIPTION
The process of conforming to [RFC-192][rfc_192] brought it to our attention that we don't in fact currently have a valid use-case for publishing our blocks to the Content Store and therefore don't need to publish a base_path. See [ADR 15: Remove dependence on base_path][adr_15].

In this commit we remove the two elements of the "publish" payload which cause a document to be lodged at the Content Store:

- `base_path`
- `routes`

See how "downstream jobs" update the Content Store only if `base_path` is present:

- [downstream draft job][draft]
- [downstream live job][live]

[rfc_192]:
https://github.com/alphagov/govuk-rfcs/pull/192/

[adr_15]:
https://github.com/alphagov/content-block-manager/blob/ea52adea1dcaeaede9b3530295abe08ae045c676/docs/architecture/decisions/0015-remove-dependence-on-base-path.md

[draft]:
https://github.com/alphagov/publishing-api/blob/42eb06a8a67d59c2f142fa9cc72d424c57c8b60c/app/sidekiq/downstream_draft_job.rb#L40

[live]:
https://github.com/alphagov/publishing-api/blob/42eb06a8a67d59c2f142fa9cc72d424c57c8b60c/app/sidekiq/downstream_live_job.rb#L43