### PR TITLE
Stub SchedulePublishingWorker dequeue method in workflow_spec

### DIFF
--- a/spec/requests/workflow_spec.rb
+++ b/spec/requests/workflow_spec.rb
@@ -709,6 +709,7 @@ RSpec.describe "Workflow", type: :request do
       describe "#update" do
         describe "when choosing to publish immediately" do
           it "redirects to the review step" do
+            allow(SchedulePublishingWorker).to receive(:dequeue)
             scheduled_at = {
               "scheduled_publication(1i)": "",
               "scheduled_publication(2i)": "",


### PR DESCRIPTION
This test has been failing locally for me as Sidekiq has attempted and failed to connect to a Redis server in the test run. That connection has nothing to do with what’s being asserted in the test, so we can safely stub out SchedulePublishingWorker’s dequeue method.