### PR TITLE
Upgrade js-yaml to 5.2.3 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-declaration-location": "^1.0.7"
   },
   "resolutions": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^5.2.1"
   },
   "dependencies": {
     "content-block-picker": "alphagov/content-block-picker#main"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@ jasmine-core@^6.3.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.2.0, js-yaml@~5.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^5.2.1, js-yaml@~5.2.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.3.tgz#0942ae8f507e22eb0e54624871789cd477106e54"
+  integrity sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
This addresses vulnerability in js-yaml (see [CVE-2026-59870][cve]).

The resolution in package.json now overrides capped js-yaml at ^4.2.0, which held it on the vulnerable 4.3.0 (quadratic CPU consumption in !!omap resolution).

Bumping to the fixed 4.3.1 is not possible as markdownlint-cli's dependency tree requires js-yaml@~5.2.1. Raising the overall resolution to ^5.2.1 is the simplest fix.

js-yaml has three consumers in the tree, and the override unifies them all onto the safe 5.2.3:

  - markdownlint-cli       requests ~5.2.1
  - cosmiconfig (stylelint) requests ^4.1.0
  - xmlbuilder2 (markdown-link-check) requests ^4.1.1

The two ^4.1.x requesters are pulled up to 5.2.3

See https://github.com/alphagov/content-block-manager/security/dependabot/135

[cve]:
https://github.com/advisories/GHSA-724g-mxrg-4qvm