### PR TITLE
CR-98: allow users to create new date range

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,8 +3,6 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/all-components";
 @import "nokodiff";
 
-@import "content-block-picker/scss/content-block-highlight";
-
 @import "components/embedded_objects/summary-card-component";
 @import "components/array-component";
 @import "components/embedded-objects-blocks-component";

--- a/app/controllers/v2/time_period_date_ranges_controller.rb
+++ b/app/controllers/v2/time_period_date_ranges_controller.rb
@@ -1,0 +1,16 @@
+module V2
+  class TimePeriodDateRangesController < ApplicationController
+    before_action :set_edition
+
+    def edit; end
+
+    def update; end
+
+  private
+
+    def set_edition
+      @edition = @document.time_period_editions.find(params[:id])
+    end
+
+  end
+end

--- a/app/controllers/v2/time_period_date_ranges_controller.rb
+++ b/app/controllers/v2/time_period_date_ranges_controller.rb
@@ -4,13 +4,31 @@ module V2
 
     def edit; end
 
-    def update; end
+    def update
+      if @edition.update(edition_params)
+        redirect_to v2_time_period_edition_path(@edition.id),
+                    notice: I18n.t("v2/time_period_edition.create.success")
+      else
+        @error_summary_errors = @edition.errors.map do |error|
+          {
+            text: error.message,
+            href: "##{error.attribute.to_s.tr('.', '_')}",
+          }
+        end
+        render :edit, status: :unprocessable_content
+      end
+    end
 
   private
 
     def set_edition
-      @edition = @document.time_period_editions.find(params[:id])
+      @edition = V2::TimePeriodEdition.find(params[:time_period_edition_id])
     end
 
+    def edition_params
+      params.require(:edition).permit(
+        date_range_attributes: %i[id start end],
+      )
+    end
   end
 end

--- a/app/controllers/v2/time_period_editions_controller.rb
+++ b/app/controllers/v2/time_period_editions_controller.rb
@@ -11,7 +11,7 @@ module V2
 
       if @edition.save
         redirect_to v2_time_period_edition_path(@edition.id),
-                    notice: I18n.t("block/time_period_edition.create.success")
+                    notice: I18n.t("v2/time_period_edition.create.success")
       else
         render :new, status: :unprocessable_content
       end

--- a/app/controllers/v2/time_period_editions_controller.rb
+++ b/app/controllers/v2/time_period_editions_controller.rb
@@ -10,8 +10,9 @@ module V2
       @edition.build_document(block_type:)
 
       if @edition.save
-        redirect_to v2_time_period_edition_path(@edition.id),
-                    notice: I18n.t("v2/time_period_edition.create.success")
+        redirect_to edit_v2_time_period_edition_time_period_date_range_path(
+          @edition,
+        )
       else
         render :new, status: :unprocessable_content
       end
@@ -29,7 +30,7 @@ module V2
 
       if @edition.save
         redirect_to v2_time_period_edition_path(@edition.id),
-                    notice: I18n.t("block/time_period_edition.update.success")
+                    notice: I18n.t("v2/time_period_edition.update.success")
       else
         render :edit, status: :unprocessable_content
       end

--- a/app/views/v2/documents/index.html.erb
+++ b/app/views/v2/documents/index.html.erb
@@ -15,6 +15,15 @@
 
     <p class="govuk-body">Create, edit and use standardised content across GOV.UK</p>
   </div>
+
+  <div class="govuk-grid-column-one-half content-block-manager-header--column-right">
+    <div>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Create time period content block",
+          href: new_v2_time_period_edition_path,
+        } %>
+    </div>
+  </div>
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">

--- a/app/views/v2/time_period_date_ranges/_form.html.erb
+++ b/app/views/v2/time_period_date_ranges/_form.html.erb
@@ -1,0 +1,203 @@
+<%= form_with(
+  model: @edition,
+  url: v2_time_period_edition_time_period_date_range_path(@edition),
+  method: @edition.persisted? ? :patch : :post,
+) do |f| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h2 class="govuk-fieldset__heading">Date range</h2>
+      </legend>
+
+      <%= f.fields_for :date_range,
+          @edition.date_range || @edition.build_date_range do |dr_fields| %>
+
+        <div class="govuk-form-group">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "Start",
+            heading_level: 3,
+            heading_size: "s",
+          } do %>
+            <%= render "govuk_publishing_components/components/date_input", {
+              hint: "For example, 27 3 2025",
+              error_items: errors_for(
+                @edition.date_range&.errors || [],
+                :start,
+              ),
+              items: [
+                {
+                  label: "Day",
+                  id: "date_range_start",
+                  name: "edition[date_range_attributes][start(3i)]",
+                  value: @edition.date_range&.start&.day,
+                  width: 2,
+                },
+                {
+                  label: "Month",
+                  name: "edition[date_range_attributes][start(2i)]",
+                  value: @edition.date_range&.start&.month,
+                  width: 2,
+                },
+                {
+                  label: "Year",
+                  name: "edition[date_range_attributes][start(1i)]",
+                  value: @edition.date_range&.start&.year,
+                  width: 4,
+                },
+              ],
+            } %>
+
+            <div class="govuk-form-group govuk-!-margin-top-4">
+              <%= render "govuk_publishing_components/components/fieldset", {
+                legend_text: "Time",
+                heading_level: 4,
+                heading_size: "s",
+              } do %>
+                <div class="govuk-hint">For example, 09:30 or 19:30</div>
+                <div class="app-c-datetime-fields__date-time-wrapper">
+                  <div class="app-c-datetime-fields__date-time">
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Hour",
+                        html_for: "start_hour",
+                      }
+                    ) %>
+                    <%= select_hour(
+                      @edition.date_range&.start&.hour,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "start(4i)",
+                      },
+                      {
+                        id: "start_hour",
+                        class: "govuk-select app-c-datetime-fields__date-time-input",
+                      },
+                    ) %>
+                  </div>
+                  <div class="app-c-datetime-fields__time-separator">:</div>
+                  <div class="app-c-datetime-fields__date-time">
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Minute",
+                        html_for: "start_minute",
+                      }
+                    ) %>
+                    <%= select_minute(
+                      @edition.date_range&.start&.min,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "start(5i)",
+                      },
+                      {
+                        id: "start_minute",
+                        class: "govuk-select app-c-datetime-fields__date-time-input",
+                      },
+                    ) %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "End",
+            heading_level: 3,
+            heading_size: "s",
+          } do %>
+            <%= render "govuk_publishing_components/components/date_input", {
+              hint: "For example, 31 3 2025",
+              error_items: errors_for(
+                @edition.date_range&.errors || [],
+                :end,
+              ),
+              items: [
+                {
+                  label: "Day",
+                  id: "date_range_end",
+                  name: "edition[date_range_attributes][end(3i)]",
+                  value: @edition.date_range&.end&.day,
+                  width: 2,
+                },
+                {
+                  label: "Month",
+                  name: "edition[date_range_attributes][end(2i)]",
+                  value: @edition.date_range&.end&.month,
+                  width: 2,
+                },
+                {
+                  label: "Year",
+                  name: "edition[date_range_attributes][end(1i)]",
+                  value: @edition.date_range&.end&.year,
+                  width: 4,
+                },
+              ],
+            } %>
+
+            <div class="govuk-form-group govuk-!-margin-top-4">
+              <%= render "govuk_publishing_components/components/fieldset", {
+                legend_text: "Time",
+                heading_level: 4,
+                heading_size: "s",
+              } do %>
+                <div class="govuk-hint">For example, 09:30 or 19:30</div>
+                <div class="app-c-datetime-fields__date-time-wrapper">
+                  <div class="app-c-datetime-fields__date-time">
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Hour",
+                        html_for: "end_hour",
+                      }
+                    ) %>
+                    <%= select_hour(
+                      @edition.date_range&.end&.hour,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "end(4i)",
+                      },
+                      {
+                        id: "end_hour",
+                        class: "govuk-select app-c-datetime-fields__date-time-input",
+                      },
+                    ) %>
+                  </div>
+                  <div class="app-c-datetime-fields__time-separator">:</div>
+                  <div class="app-c-datetime-fields__date-time">
+                    <%= render(
+                      "govuk_publishing_components/components/label", {
+                        text: "Minute",
+                        html_for: "end_minute",
+                      }
+                    ) %>
+                    <%= select_minute(
+                      @edition.date_range&.end&.min,
+                      {
+                        include_blank: true,
+                        prefix: "edition[date_range_attributes]",
+                        field_name: "end(5i)",
+                      },
+                      {
+                        id: "end_minute",
+                        class: "govuk-select app-c-datetime-fields__date-time-input",
+                      },
+                    ) %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+
+      <% end %>
+    </fieldset>
+  </div>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save and continue",
+    type: "submit",
+  } %>
+<% end %>

--- a/app/views/v2/time_period_date_ranges/edit.html.erb
+++ b/app/views/v2/time_period_date_ranges/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, "Edit time period block" %>
+<% content_for :back_link,
+   render("govuk_publishing_components/components/back_link", {
+     href: v2_time_period_edition_time_period_date_range_path(@edition),
+   }) %>
+
+ <% if @error_summary_errors %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: @error_summary_errors,
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/v2/time_period_editions/edit.html.erb
+++ b/app/views/v2/time_period_editions/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, I18n.t("block/time_period_edition.edit.context") %>
-<% content_for :title, I18n.t("block/time_period_edition.edit.title") %>
+<% content_for :context, I18n.t("v2/time_period_edition.edit.context") %>
+<% content_for :title, I18n.t("v2/time_period_edition.edit.title") %>
 
 <%= render "form", url: v2_time_period_edition_path, method: :put %>

--- a/app/views/v2/time_period_editions/new.html.erb
+++ b/app/views/v2/time_period_editions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, I18n.t("block/time_period_edition.new.context") %>
-<% content_for :title, I18n.t("block/time_period_edition.new.title") %>
+<% content_for :context, I18n.t("v2/time_period_edition.new.context") %>
+<% content_for :title, I18n.t("v2/time_period_edition.new.title") %>
 
 <%= render "form", url: v2_time_period_editions_path, method: :post %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
             lead_organisation_id:
               blank: "cannot be blank"
         v2/time_period_date_range:
+          format: "%{message}"
           attributes:
             start:
               blank: "Enter a start date"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,7 +435,7 @@ en:
       hour: Hour
       minute: Minute
 
-  block/time_period_edition:
+  v2/time_period_edition:
     new:
       title: "Create time period"
       context: "Create content block"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,12 @@ Rails.application.routes.draw do
   end
 
   namespace :v2 do
-    resources :time_period_editions, only: %i[new create show edit update]
+    resources :time_period_editions, only: %i[new create show edit update] do
+      resource :time_period_date_range,
+               only: %i[edit update],
+               path: "time-period-date-range"
+    end
+
     resources :documents, only: [:index]
   end
 

--- a/features/step_definitions/v2/block_creation_steps.rb
+++ b/features/step_definitions/v2/block_creation_steps.rb
@@ -74,3 +74,44 @@ end
 Then("I should not see {string}") do |content|
   expect(page).to have_no_content(content)
 end
+
+When("I fill the date range details incorrectly") do
+  start_date = 2.days.before(Time.zone.now)
+  end_date = 10.days.before(Time.zone.now)
+
+  fill_in "edition[date_range_attributes][start(3i)]", with: start_date.day
+  fill_in "edition[date_range_attributes][start(2i)]", with: start_date.month
+  fill_in "edition[date_range_attributes][start(1i)]", with: start_date.year
+
+  fill_in "edition[date_range_attributes][end(3i)]", with: end_date.day
+  fill_in "edition[date_range_attributes][end(2i)]", with: end_date.month
+  fill_in "edition[date_range_attributes][end(1i)]", with: end_date.year
+end
+
+And("I fill the date range details correctly") do
+  start_date = 10.days.before(Time.zone.now)
+  end_date = 2.days.before(Time.zone.now)
+
+  fill_in "edition[date_range_attributes][start(3i)]", with: start_date.day
+  fill_in "edition[date_range_attributes][start(2i)]", with: start_date.month
+  fill_in "edition[date_range_attributes][start(1i)]", with: start_date.year
+
+  fill_in "edition[date_range_attributes][end(3i)]", with: end_date.day
+  fill_in "edition[date_range_attributes][end(2i)]", with: end_date.month
+  fill_in "edition[date_range_attributes][end(1i)]", with: end_date.year
+end
+
+Then("I see errors telling me to enter values") do
+  expect(page).to have_content("Enter a start date")
+  expect(page).to have_content("Enter an end date")
+end
+
+And("I continue to the date range page") do
+  click_button("Save and continue")
+
+  edition = V2::TimePeriodEdition.last
+
+  expect(current_path).to eq(edit_v2_time_period_edition_time_period_date_range_path(
+                               edition,
+                             ))
+end

--- a/features/step_definitions/v2/edition_steps.rb
+++ b/features/step_definitions/v2/edition_steps.rb
@@ -25,7 +25,7 @@ When("I fill the Time Period Edition details incorrectly") do
 end
 
 Then("I see that the Edition was created successfully") do
-  expect(page).to have_content(I18n.t("block/time_period_edition.create.success"))
+  expect(page).to have_content(I18n.t("v2/time_period_edition.create.success"))
 end
 
 Then("I see that the Edition was updated successfully") do

--- a/features/step_definitions/v2/edition_steps.rb
+++ b/features/step_definitions/v2/edition_steps.rb
@@ -29,7 +29,7 @@ Then("I see that the Edition was created successfully") do
 end
 
 Then("I see that the Edition was updated successfully") do
-  expect(page).to have_content(I18n.t("block/time_period_edition.update.success"))
+  expect(page).to have_content(I18n.t("v2/time_period_edition.update.success"))
 end
 
 When("a Time Period Edition exists") do

--- a/features/v2/time_period/create_block.feature
+++ b/features/v2/time_period/create_block.feature
@@ -10,6 +10,8 @@ Feature: Create Time Period Edition
 
   Scenario: Editor can create a new Time Period Edition
     When I fill the Time Period Edition details correctly
+    And I continue to the date range page
+    And I fill the date range details correctly
     And I save and continue
     Then I see that the Edition was created successfully
 
@@ -17,3 +19,9 @@ Feature: Create Time Period Edition
     When I fill the Time Period Edition details incorrectly
     And I save and continue
     Then I see which Time Period Edition errors I need to correct
+
+  Scenario: Editor is informed when creating a date range incorrectly
+    When I fill the Time Period Edition details correctly
+    And I continue to the date range page
+    And I save and continue
+    Then I see errors telling me to enter values

--- a/spec/requests/v2/time_period_date_range_spec.rb
+++ b/spec/requests/v2/time_period_date_range_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe "V2::TimePeriodDateRange", type: :request do
+  setup do
+    logout
+    user = create(:user)
+    login_as(user)
+  end
+
+  describe "PATCH /v2/time_period_editions/:time_period_edition_id/time-period-date-range" do
+    let(:edition) do
+      create(:v2_time_period_edition, title: "Old Title", description: "Old")
+    end
+    let(:document) { edition.document }
+
+    let(:valid_date_range_attributes) do
+      {
+        edition: {
+          date_range_attributes: {
+            start: "2025-04-06 09:00",
+            end: "2026-04-05 17:30",
+          },
+        },
+      }
+    end
+
+    let(:invalid_date_range_attributes) do
+      {
+        edition: {
+          date_range_attributes: {
+            start: "2026-04-06 09:00",
+            end: "2025-04-05 17:30", # End before start
+          },
+        },
+      }
+    end
+
+    context "with valid parameters" do
+      it "updates the date range" do
+        patch v2_time_period_edition_time_period_date_range_path(edition),
+              params: valid_date_range_attributes
+        edition.reload
+        expect(edition.date_range.start).to eq(
+          Time.zone.parse("2025-04-06 09:00"),
+        )
+        expect(edition.date_range.end).to eq(
+          Time.zone.parse("2026-04-05 17:30"),
+        )
+      end
+
+      it "redirects to the edition with a success message" do
+        patch v2_time_period_edition_time_period_date_range_path(edition),
+              params: valid_date_range_attributes
+        expect(response).to redirect_to(
+          v2_time_period_edition_path(edition),
+        )
+        expect(flash[:notice]).to eq(I18n.t("v2/time_period_edition.create.success"))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not update the edition" do
+        original_start = edition.date_range&.start
+        patch v2_time_period_edition_time_period_date_range_path(edition),
+              params: invalid_date_range_attributes
+        edition.reload
+        expect(edition.date_range&.start).to eq(original_start)
+      end
+
+      it "returns unprocessable entity status" do
+        patch v2_time_period_edition_time_period_date_range_path(edition),
+              params: invalid_date_range_attributes
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the edit template" do
+        patch v2_time_period_edition_time_period_date_range_path(edition),
+              params: invalid_date_range_attributes
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/requests/v2/time_period_editions_spec.rb
+++ b/spec/requests/v2/time_period_editions_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "V2 time period editions", type: :request do
 
         expect(response).to redirect_to(v2_time_period_edition_path(V2::TimePeriodEdition.last.id))
         follow_redirect!
-        expect(response.body).to include(I18n.t("block/time_period_edition.create.success"))
+        expect(response.body).to include(I18n.t("v2/time_period_edition.create.success"))
       end
     end
 

--- a/spec/requests/v2/time_period_editions_spec.rb
+++ b/spec/requests/v2/time_period_editions_spec.rb
@@ -72,16 +72,15 @@ RSpec.describe "V2 time period editions", type: :request do
         }
       end
 
-      it "creates a new time period edition and redirects to the time period edition page with a success message" do
+      it "creates a new time period edition and redirects to the date range page" do
         expect {
           post v2_time_period_editions_path, params: valid_params
         }.to change(V2::TimePeriodEdition, :count).by(1)
 
         expected_created_edition = V2::TimePeriodEdition.last
 
-        expect(response).to redirect_to(edit_v2_document_time_period_date_range_path(expected_created_edition.document, expected_created_edition))
+        expect(response).to redirect_to(edit_v2_time_period_edition_time_period_date_range_path(expected_created_edition))
         follow_redirect!
-        expect(response.body).to include(I18n.t("v2/time_period_edition.create.success"))
       end
     end
 
@@ -157,7 +156,7 @@ RSpec.describe "V2 time period editions", type: :request do
 
       expect(response).to redirect_to(v2_time_period_edition_path(existing_edition.id))
       follow_redirect!
-      expect(response.body).to include(I18n.t("block/time_period_edition.update.success"))
+      expect(response.body).to include(I18n.t("v2/time_period_edition.update.success"))
     end
 
     it "re-renders the edit form with errors when invalid parameters are provided" do

--- a/spec/requests/v2/time_period_editions_spec.rb
+++ b/spec/requests/v2/time_period_editions_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe "V2 time period editions", type: :request do
           post v2_time_period_editions_path, params: valid_params
         }.to change(V2::TimePeriodEdition, :count).by(1)
 
-        expect(response).to redirect_to(v2_time_period_edition_path(V2::TimePeriodEdition.last.id))
+        expected_created_edition = V2::TimePeriodEdition.last
+
+        expect(response).to redirect_to(edit_v2_document_time_period_date_range_path(expected_created_edition.document, expected_created_edition))
         follow_redirect!
         expect(response.body).to include(I18n.t("v2/time_period_edition.create.success"))
       end


### PR DESCRIPTION
Allows users to add a date range to a refactored, v2 time period edition.

Credit to @edavey for a good portion of the implementation, from his original [experimental branch.
](https://github.com/alphagov/content-block-manager/pull/553)
https://github.com/user-attachments/assets/74dc13d8-b9bb-41a5-be02-2157747e87f5