### PR TITLE
(CR-45) Pull content block picker from NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This README is for developers using content-block-manager, to view publisher doc
 
 ## Block Picker Demo
 
-There is a built in demo of the block picker that can be used to test the block picker functionality. To run the demo, run the application and navigate to: /content-block-picker-demo
+There is a built-in demo of the block picker that can be used to test the block picker functionality. To run the demo, run the application and navigate to: /content-block-picker-demo
 
-Currently, the NPM bundling for CBP is broken, so we pull the code directly from GitHub. Yarn caches very efficiently, so if you have previously run the demo, you may need to clear your yarn cache to get the latest version of the code. You can do this by running:
+Yarn caches very efficiently, so if you have previously run the demo, you may need to clear your yarn cache to get the latest version of the code. You can do this by running:
 
 ### When running in govuk docker
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,4 +2,3 @@
 //= link application.js
 //= link domain-config.js
 //= link es6-components.js
-//= link content-block-picker/dist/content-block-picker.umd.cjs

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,8 @@
 //= require components/array-component
 //= require components/govspeak-editor
 
+//= require content-block-picker/dist/content-block-picker.umd
+
 //= require ./modules/copy-embed-code
 //= require ./modules/ga4-form-setup
 //= require ./modules/unsaved-changes-prompt

--- a/app/views/pages/content_block_picker_demo.html.erb
+++ b/app/views/pages/content_block_picker_demo.html.erb
@@ -1,6 +1,3 @@
-<% content_for :head do %>
-  <script src="<%= asset_path("content-block-picker/dist/content-block-picker.umd.cjs") %>"></script>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "js-yaml": "^5.2.1"
   },
   "dependencies": {
-    "content-block-picker": "alphagov/content-block-picker#main"
+    "content-block-picker": "^1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,12 +761,12 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-content-block-picker@alphagov/content-block-picker#main:
-  version "1.0.0"
-  uid bdb973d17a968fcde1738d5484ae5c1f508469d8
-  resolved "https://codeload.github.com/alphagov/content-block-picker/tar.gz/bdb973d17a968fcde1738d5484ae5c1f508469d8"
+content-block-picker@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/content-block-picker/-/content-block-picker-1.0.2.tgz#bee930bbfa29d5ac15f981bb48dbbeb9583457ce"
+  integrity sha512-1vsNxbQSD0T61fGBWWnqQ52a81rqe4MwbvAUYZraaWC2zPYe6j0ZOVt6spGO5anS9JOMWA8chutgjtdgIeeIuQ==
   dependencies:
-    dompurify "^3.4.12"
+    dompurify "^3.4.13"
     govuk-frontend "^6.4.0"
 
 content-disposition@^1.0.0:
@@ -980,10 +980,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.4.12:
-  version "3.4.13"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
-  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
+dompurify@^3.4.13:
+  version "3.4.14"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.14.tgz#a789edb2c7bcdb69a93713a34edb7e0a5245d8c9"
+  integrity sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
Pull content-block-picker from NPM.

Slight tweaks to the way it's imported to add it to the `application.js` bundle with the rest of our UMD modules.

Removes the inline script tag as it's no longer needed.