### PR TITLE
(CR-145) Ignore slack links in markdown when linting

### DIFF
--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https?://localhost"
+    },
+    {
+      "pattern": "https?://.*.slack.com/archives/.*"
     }
   ]
 }


### PR DESCRIPTION
Slack has introduced browser detection in their links, meaning that when the markdown-link-check tool runs it receives a 403 status code when checking links to slack channels. This marks the link as broken.

As such, the easy fix is to ignore links to slack when doing these checks. This does mean that if this link really becomes dead then we may not know.

I tried allowing cookies to be saved locally when accessing these links programmatically but this didn’t seem to fix it. I’m not sure how exactly they are calculating if a user is using a browser but I haven't found a way around it.

# Jira Ticket

https://gov-uk.atlassian.net/browse/CR-145

